### PR TITLE
Add Push Token Registration Methods

### DIFF
--- a/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
+++ b/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
@@ -85,6 +85,11 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void registerPushToken(String token) {
+    Appboy.getInstance(getReactApplicationContext()).registerAppboyPushMessages(token);
+  }
+
+  @ReactMethod
   public void logCustomEvent(String eventName, ReadableMap eventProperties) {
     Appboy.getInstance(getReactApplicationContext()).logCustomEvent(eventName, populateEventPropertiesFromReadableMap(eventProperties));
   }

--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -56,6 +56,12 @@ RCT_EXPORT_METHOD(changeUser:(NSString *)userId)
   [[Appboy sharedInstance] changeUser:userId];
 }
 
+RCT_EXPORT_METHOD(registerPushToken:(NSString *)token)
+{
+  RCTLogInfo(@"[Appboy sharedInstance] registerPushToken with value %@", token);
+  [[Appboy sharedInstance] registerPushToken:token];
+}
+
 RCT_EXPORT_METHOD(submitFeedback:(NSString *)replyToEmail message:(NSString *)message isReportingABug:(BOOL)isReportingABug callback:(RCTResponseSenderBlock)callback)
 {
   RCTLogInfo(@"[Appboy sharedInstance] submitFeedback with values %@ %@ %@", replyToEmail, message, isReportingABug ? @"true" : @"false");

--- a/index.js
+++ b/index.js
@@ -95,6 +95,15 @@ var ReactAppboy = {
   },
 
   /**
+  * This method posts a token to Appboy's servers to associate the token with the current device.
+  *
+  * @param {string} token - The device's push token.
+  */
+  registerPushToken: function(token) {
+    AppboyReactBridge.registerPushToken(token);
+  },
+
+  /**
   * Reports that the current user performed a custom named event.
   * @param {string} eventName - The identifier for the event to track. Best practice is to track generic events
   *      useful for segmenting, instead of specific user actions (i.e. track watched_sports_video instead of


### PR DESCRIPTION
The ReactNative SDK does not currently support reporting push notification tokens. This PR will add those methods.