### PR TITLE
Add podspec and explain usage

### DIFF
--- a/AppboyProject/ios/Podfile
+++ b/AppboyProject/ios/Podfile
@@ -4,5 +4,5 @@ target 'AppboyProject' do
   pod 'Appboy-iOS-SDK'
 
   # if you want to integrate through Cocoapods instead of manual linking
-  pod 'react-native-appboy-sdk', :path => '../node_modules/react-native-appboy-sdk'
+  # pod 'react-native-appboy-sdk', :path => '../node_modules/react-native-appboy-sdk'
 end

--- a/AppboyProject/ios/Podfile
+++ b/AppboyProject/ios/Podfile
@@ -1,5 +1,8 @@
 
-target 'AppboyProject' do 
+target 'AppboyProject' do
   platform :ios, '8.0'
   pod 'Appboy-iOS-SDK'
+
+  # if you want to integrate through Cocoapods instead of manual linking
+  pod 'react-native-appboy-sdk', :path => '../node_modules/react-native-appboy-sdk'
 end

--- a/AppboyProject/ios/Podfile
+++ b/AppboyProject/ios/Podfile
@@ -3,18 +3,18 @@ target 'AppboyProject' do
 
   # if you want to integrate through Cocoapods instead of manual linking use this:
   # it already comes with a dependency on `Appboy-iOS-SDK` so you're all set
-  pod 'react-native-appboy-sdk', :path => '../node_modules/react-native-appboy-sdk'
-
-  pod 'React', :path => '../node_modules/react-native', :subspecs => [
-    'Core',
-    'RCTText',
-    'RCTAnimation',
-    'RCTImage',
-    'RCTNetwork',
-    'RCTVibration'
-  ]
+  #
+  # pod 'react-native-appboy-sdk', :path => '../node_modules/react-native-appboy-sdk'
+  # pod 'React', :path => '../node_modules/react-native', :subspecs => [
+  #   'Core',
+  #   'RCTText',
+  #   'RCTAnimation',
+  #   'RCTImage',
+  #   'RCTNetwork',
+  #   'RCTVibration'
+  # ]
 
   # Otherwise you still need to depend on the iOS SDK here
-  # pod 'Appboy-iOS-SDK'
+  pod 'Appboy-iOS-SDK'
 
 end

--- a/AppboyProject/ios/Podfile
+++ b/AppboyProject/ios/Podfile
@@ -1,8 +1,11 @@
-
 target 'AppboyProject' do
   platform :ios, '8.0'
+
+  # if you want to integrate through Cocoapods instead of manual linking use this:
+  # it already comes with a dependency on `Appboy-iOS-SDK` so you're all set
+  # pod 'react-native-appboy-sdk', :path => '../node_modules/react-native-appboy-sdk'
+
+  # Otherwise you still need to depend on the iOS SDK here
   pod 'Appboy-iOS-SDK'
 
-  # if you want to integrate through Cocoapods instead of manual linking
-  # pod 'react-native-appboy-sdk', :path => '../node_modules/react-native-appboy-sdk'
 end

--- a/AppboyProject/ios/Podfile
+++ b/AppboyProject/ios/Podfile
@@ -3,9 +3,18 @@ target 'AppboyProject' do
 
   # if you want to integrate through Cocoapods instead of manual linking use this:
   # it already comes with a dependency on `Appboy-iOS-SDK` so you're all set
-  # pod 'react-native-appboy-sdk', :path => '../node_modules/react-native-appboy-sdk'
+  pod 'react-native-appboy-sdk', :path => '../node_modules/react-native-appboy-sdk'
+
+  pod 'React', :path => '../node_modules/react-native', :subspecs => [
+    'Core',
+    'RCTText',
+    'RCTAnimation',
+    'RCTImage',
+    'RCTNetwork',
+    'RCTVibration'
+  ]
 
   # Otherwise you still need to depend on the iOS SDK here
-  pod 'Appboy-iOS-SDK'
+  # pod 'Appboy-iOS-SDK'
 
 end

--- a/AppboyProject/ios/Podfile.lock
+++ b/AppboyProject/ios/Podfile.lock
@@ -6,53 +6,19 @@ PODS:
     - Appboy-iOS-SDK/Core
     - SDWebImage/GIF (~> 4.0)
   - FLAnimatedImage (1.0.12)
-  - react-native-appboy-sdk (1.3.0):
-    - Appboy-iOS-SDK (~> 3.0)
-  - React/Core (0.41.2):
-    - React/cxxreact
-    - React/yoga
-  - React/cxxreact (0.41.2):
-    - React/jschelpers
-  - React/jschelpers (0.41.2)
-  - React/RCTAnimation (0.41.2):
-    - React/Core
-  - React/RCTImage (0.41.2):
-    - React/Core
-    - React/RCTNetwork
-  - React/RCTNetwork (0.41.2):
-    - React/Core
-  - React/RCTText (0.41.2):
-    - React/Core
-  - React/RCTVibration (0.41.2):
-    - React/Core
-  - React/yoga (0.41.2)
   - SDWebImage/Core (4.1.0)
   - SDWebImage/GIF (4.1.0):
     - FLAnimatedImage (~> 1.0)
     - SDWebImage/Core
 
 DEPENDENCIES:
-  - react-native-appboy-sdk (from `../node_modules/react-native-appboy-sdk`)
-  - React/Core (from `../node_modules/react-native`)
-  - React/RCTAnimation (from `../node_modules/react-native`)
-  - React/RCTImage (from `../node_modules/react-native`)
-  - React/RCTNetwork (from `../node_modules/react-native`)
-  - React/RCTText (from `../node_modules/react-native`)
-  - React/RCTVibration (from `../node_modules/react-native`)
-
-EXTERNAL SOURCES:
-  React:
-    :path: "../node_modules/react-native"
-  react-native-appboy-sdk:
-    :path: "../node_modules/react-native-appboy-sdk"
+  - Appboy-iOS-SDK
 
 SPEC CHECKSUMS:
   Appboy-iOS-SDK: 48825353e29e731b8d55b7927b26f49be32f4c1d
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
-  React: 2b10c07d947dea71c144a33764e9162ed81e3825
-  react-native-appboy-sdk: 53856979ebc470678cbeaa52b21e542e766a6f4e
   SDWebImage: 0e435c14e402a6730315a0fb79f95e68654d55a4
 
-PODFILE CHECKSUM: 59f510b8302c62daa26f2c9001cef23e0530d1a2
+PODFILE CHECKSUM: 1f57b0b94313a298608387f36d9743aa0be0d96e
 
 COCOAPODS: 1.2.1

--- a/AppboyProject/ios/Podfile.lock
+++ b/AppboyProject/ios/Podfile.lock
@@ -1,22 +1,58 @@
 PODS:
-  - Appboy-iOS-SDK (2.29.0):
-    - Appboy-iOS-SDK/UI (= 2.29.0)
-  - Appboy-iOS-SDK/UI (2.29.0):
+  - Appboy-iOS-SDK (3.0.1):
+    - Appboy-iOS-SDK/UI (= 3.0.1)
+  - Appboy-iOS-SDK/Core (3.0.1)
+  - Appboy-iOS-SDK/UI (3.0.1):
+    - Appboy-iOS-SDK/Core
     - SDWebImage/GIF (~> 4.0)
   - FLAnimatedImage (1.0.12)
-  - SDWebImage/Core (4.0.0)
-  - SDWebImage/GIF (4.0.0):
+  - react-native-appboy-sdk (1.3.0):
+    - Appboy-iOS-SDK (~> 3.0)
+  - React/Core (0.41.2):
+    - React/cxxreact
+    - React/yoga
+  - React/cxxreact (0.41.2):
+    - React/jschelpers
+  - React/jschelpers (0.41.2)
+  - React/RCTAnimation (0.41.2):
+    - React/Core
+  - React/RCTImage (0.41.2):
+    - React/Core
+    - React/RCTNetwork
+  - React/RCTNetwork (0.41.2):
+    - React/Core
+  - React/RCTText (0.41.2):
+    - React/Core
+  - React/RCTVibration (0.41.2):
+    - React/Core
+  - React/yoga (0.41.2)
+  - SDWebImage/Core (4.1.0)
+  - SDWebImage/GIF (4.1.0):
     - FLAnimatedImage (~> 1.0)
     - SDWebImage/Core
 
 DEPENDENCIES:
-  - Appboy-iOS-SDK
+  - react-native-appboy-sdk (from `../node_modules/react-native-appboy-sdk`)
+  - React/Core (from `../node_modules/react-native`)
+  - React/RCTAnimation (from `../node_modules/react-native`)
+  - React/RCTImage (from `../node_modules/react-native`)
+  - React/RCTNetwork (from `../node_modules/react-native`)
+  - React/RCTText (from `../node_modules/react-native`)
+  - React/RCTVibration (from `../node_modules/react-native`)
+
+EXTERNAL SOURCES:
+  React:
+    :path: "../node_modules/react-native"
+  react-native-appboy-sdk:
+    :path: "../node_modules/react-native-appboy-sdk"
 
 SPEC CHECKSUMS:
-  Appboy-iOS-SDK: 4c415ccf7e22e131326a9bcb89c840f87f6fdd2f
+  Appboy-iOS-SDK: 48825353e29e731b8d55b7927b26f49be32f4c1d
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
-  SDWebImage: 76a6348bdc74eb5a55dd08a091ef298e56b55e41
+  React: 2b10c07d947dea71c144a33764e9162ed81e3825
+  react-native-appboy-sdk: 53856979ebc470678cbeaa52b21e542e766a6f4e
+  SDWebImage: 0e435c14e402a6730315a0fb79f95e68654d55a4
 
-PODFILE CHECKSUM: 2f9e055aff739205d78aff436edf9dc0a9a94678
+PODFILE CHECKSUM: 59f510b8302c62daa26f2c9001cef23e0530d1a2
 
 COCOAPODS: 1.2.1

--- a/react-native-appboy-sdk.podspec
+++ b/react-native-appboy-sdk.podspec
@@ -1,0 +1,22 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = package['name']
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = package['homepage']
+  s.source         = { :git => 'git+https://github.com/Appboy/appboy-react-sdk.git', :tag => s.version }
+
+  s.requires_arc   = true
+  s.platform       = :ios, '8.0'
+
+  s.preserve_paths = 'LICENSE.md', 'README.md', 'package.json', 'index.js'
+  s.source_files   = 'iOS/**/*.{h,m}'
+
+  s.dependency 'React'
+end

--- a/react-native-appboy-sdk.podspec
+++ b/react-native-appboy-sdk.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE.md', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'iOS/**/*.{h,m}'
 
-  s.dependency 'React'
+  s.dependency 'Appboy-iOS-SDK', '~> 3.0'
 end


### PR DESCRIPTION
To allow using this SDK through cocoapods it needs a podspec. This is quite a common pattern and allows for not having to link native dependencies by hand but just point to the `node_modules`.

It's quite a common pattern in third-party native libs. For example:

* [React Native Image picker](https://github.com/react-community/react-native-image-picker/blob/develop/react-native-image-picker.podspec)
* [RNSVG](https://github.com/react-native-community/react-native-svg/blob/master/RNSVG.podspec)
* [react-native-keychain](https://github.com/oblador/react-native-keychain/blob/master/RNKeychain.podspec)
* A pull request in the Adjust React Native SDK: https://github.com/adjust/react_native_sdk/pull/14