### PR TITLE
Bump appboy-android-sdk dependency version to 2.0.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,6 @@ android {
 }
 
 dependencies {
-  compile 'com.appboy:android-sdk-ui:2.0.0'
+  compile 'com.appboy:android-sdk-ui:2.0.5'
   compile 'com.facebook.react:react-native:0.19.+'
 }


### PR DESCRIPTION
Previously, this SDK was pulling in version 2.0.0 of the Android sdk. There seem to have been a few updates since then, including one fairly critical ([2.0.5](https://github.com/Appboy/appboy-android-sdk/blob/master/CHANGELOG.md)) to how we're using the SDK that was resulting in crashes at runtime for our users.

This bumps that to include the latest version. Any better way to keep this in sync as the Android SDK version changes?