### PR TITLE
Fixes podspec for apps that have 'use_frameworks' in Podfile

### DIFF
--- a/react-native-appboy-sdk.podspec
+++ b/react-native-appboy-sdk.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'iOS/**/*.{h,m}'
 
   s.dependency 'Appboy-iOS-SDK', '~> 3.0'
+  s.dependency 'React'
 end


### PR DESCRIPTION
If an app using `use_frameworks!` in their `Podfile` tries to use `react-native-appboy-sdk.podspec`, compilation will fail. The failure message will be something about how `<React/*.h>` does not exist where `*` can be `RCTLog` or `RCTEventEmitter` depending on which file failed compilation first.

I took the solution from here: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/1618