### PR TITLE
Fixes incorrect class in react bridge

### DIFF
--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -289,7 +289,7 @@ RCT_EXPORT_METHOD(getUnreadCardCountForCategories:(NSString *)category callback:
 
 RCT_EXPORT_METHOD(launchFeedback) {
   RCTLogInfo(@"launchFeedback called");
-  ABKFeedbackViewControllerModalContext *feedbackModal = [[ABKFeedbackViewControllerModalContext alloc] init];
+  ABKFeedViewControllerModalContext *feedbackModal = [[ABKFeedViewControllerModalContext alloc] init];
   UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
   UIViewController *mainViewController = keyWindow.rootViewController;
   [mainViewController presentViewController:feedbackModal animated:YES completion:nil];


### PR DESCRIPTION
When trying to build the example project (and my own project), I received a warning that `ABKFeedbackViewControllerModalContext` did not exist. It appears to have been renamed.