### PR TITLE
Implement requiresMainQueueSetup to prevent warning in RN 0.49+

### DIFF
--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -20,6 +20,10 @@ RCT_ENUM_CONVERTER(ABKNotificationSubscriptionType,
   return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 - (NSDictionary *)constantsToExport
 {
   return @{@"subscribed":@(ABKSubscribed), @"unsubscribed":@(ABKUnsubscribed),@"optedin":@(ABKOptedIn)};


### PR DESCRIPTION
Since RN 0.49 `requiresMainQueueSetup` should be implemented if you override `constantsToExport`. Without this a warning is shown every time the app launches.

Other libraries already implemented this:
https://github.com/wix/react-native-navigation/pull/1983
https://github.com/dooboolab/react-native-iap/pull/83