### PR TITLE
Fix podspec to point to correct iOS version v3.5.1

### DIFF
--- a/react-native-appboy-sdk.podspec
+++ b/react-native-appboy-sdk.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE.md', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'iOS/**/*.{h,m}'
 
-  s.dependency 'Appboy-iOS-SDK', '~> 3.3.3'
+  s.dependency 'Appboy-iOS-SDK', '~> 3.5.1'
   s.dependency 'React'
 end


### PR DESCRIPTION
Latest version (v1.7.0) updates to v3.5.1, but the podspec still points to an old version.