### PR TITLE
Added content cards custom ui bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## vNext (Unreleased)
+
+##### Breaking
+- Updated the native Android bridge to [Braze Android SDK 3.4.0](https://github.com/Appboy/appboy-android-sdk/blob/master/CHANGELOG.md#340).
+  - Please note the breaking push changes in release 3.1.1 regarding the AppboyFirebaseMessagingService before upgrading to this version.
+
+##### Added
+
+You can create your own Content Cards interface by using the following methods.
+You can create a completely custom view and subscribe for data updates.
+In the latter case, you would need to log all view events, dismissed events, and clicks manually.
+
+- Added `getContentCards` for getting content cards data.
+- Added `logContentCardsDisplayed` for manually logging all cards impressions.
+- Added `logContentCardClicked` for manually logging a click to Braze for a particular card.
+- Added `logContentCardImpression` for manually logging an impression to Braze for a particular card.
+- Added `logContentCardDismissed` for manually logging a dismissal to Braze for a particular card.
+- Added `addListener`, `removeListener` for subscribing to the events:
+  - `contentCardsUpdated` - content cards update succeed. You can use `getContentCards` to retrieve updated cards.
+
+##### Fixed
+- Added `addAlias` typescript definition.
+- Added `setLanguage` typescript definition.
+
 ## 1.13.0
 
 ##### Breaking

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,6 @@ android {
 }
 
 dependencies {
-  api 'com.appboy:android-sdk-ui:3.3.0'
+  api 'com.appboy:android-sdk-ui:3.4.0'
   api 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
+++ b/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
@@ -738,7 +738,7 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
   private void logContentCardDismissed(String id) {
     Card card = getCardById(id);
     if (card != null) {
-      card.card.setIsDismissed(true);
+      card.setIsDismissed(true);
     }
   }
 

--- a/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
+++ b/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
@@ -735,7 +735,7 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  private void logContentCardDismissed() {
+  private void logContentCardDismissed(String id) {
     Card card = getCardById(id);
     if (card != null) {
       card.card.setIsDismissed(true);

--- a/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
+++ b/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
@@ -710,9 +710,11 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
       @Override
       public void trigger(ContentCardsUpdatedEvent event) {
         boolean updated = event.getLastUpdatedInSecondsFromEpoch() > mContentCardsUpdatedAt;
-        getReactApplicationContext()
-          .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-          .emit(CONTENT_CARDS_UPDATED_EVENT_NAME, updated);
+        if (updated) {
+            getReactApplicationContext()
+              .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+              .emit(CONTENT_CARDS_UPDATED_EVENT_NAME, updated);
+        }
         updateContentCardsIfNeeded(event);
       }
     };

--- a/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
+++ b/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
@@ -734,7 +734,10 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
 
   @ReactMethod
   private void logContentCardDismissed() {
-    // TODO: is it possible to implement?
+    Card card = getCardById(id);
+    if (card != null) {
+      card.card.setIsDismissed(true);
+    }
   }
 
   @ReactMethod

--- a/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
+++ b/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
@@ -1,6 +1,7 @@
 package com.appboy.reactbridge;
 
 import android.content.Intent;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.appboy.Appboy;
@@ -8,8 +9,14 @@ import com.appboy.enums.Gender;
 import com.appboy.enums.Month;
 import com.appboy.enums.NotificationSubscriptionType;
 import com.appboy.enums.CardCategory;
+import com.appboy.events.ContentCardsUpdatedEvent;
 import com.appboy.events.FeedUpdatedEvent;
 import com.appboy.events.IEventSubscriber;
+import com.appboy.models.cards.BannerImageCard;
+import com.appboy.models.cards.CaptionedImageCard;
+import com.appboy.models.cards.Card;
+import com.appboy.models.cards.ShortNewsCard;
+import com.appboy.models.cards.TextAnnouncementCard;
 import com.appboy.models.outgoing.AppboyProperties;
 import com.appboy.models.outgoing.AttributionData;
 import com.appboy.models.outgoing.FacebookUser;
@@ -19,6 +26,8 @@ import com.appboy.support.AppboyLogger;
 import com.appboy.ui.activities.AppboyContentCardsActivity;
 import com.appboy.ui.activities.AppboyFeedActivity;
 import com.appboy.ui.inappmessage.AppboyInAppMessageManager;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -27,6 +36,9 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import org.json.JSONObject;
 
@@ -44,12 +56,17 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
   private static final String UNREAD_CARD_COUNT_TAG = "unread card count";
   private static final String DURATION_SHORT_KEY = "SHORT";
   private static final String DURATION_LONG_KEY = "LONG";
+  private static final String CONTENT_CARDS_UPDATED_EVENT_NAME = "contentCardsUpdated";
   private final Object mCallbackWasCalledMapLock = new Object();
+  private IEventSubscriber<ContentCardsUpdatedEvent> mContentCardsUpdatedSubscriber;
+  private final List<Card> mContentCards = new ArrayList<>();
+  private long mContentCardsUpdatedAt = 0;
   private Map<Callback, IEventSubscriber<FeedUpdatedEvent>> mFeedSubscriberMap = new ConcurrentHashMap<Callback, IEventSubscriber<FeedUpdatedEvent>>();
   private Map<Callback, Boolean> mCallbackWasCalledMap = new ConcurrentHashMap<Callback, Boolean>();
 
   public AppboyReactBridge(ReactApplicationContext reactContext) {
     super(reactContext);
+    subscribeToContentCardsUpdatedEvent();
   }
 
   @Override
@@ -399,13 +416,6 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void launchContentCards() {
-    Intent intent = new Intent(getCurrentActivity(), AppboyContentCardsActivity.class);
-    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-    this.getReactApplicationContext().startActivity(intent);
-  }
-
-  @ReactMethod
   public void requestFeedRefresh() {
     Appboy.getInstance(getReactApplicationContext()).requestFeedRefresh();
   }
@@ -530,11 +540,6 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void requestContentCardsRefresh() {
-    Appboy.getInstance(getReactApplicationContext()).requestContentCardsRefresh(false);
-  }
-
-  @ReactMethod
   public void hideCurrentInAppMessage() {
     AppboyInAppMessageManager.getInstance().hideCurrentlyDisplayingInAppMessage(true);
   }
@@ -580,4 +585,181 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
         return null;
     }
   }
+
+  // region - Content Cards -
+  @ReactMethod
+  public void launchContentCards() {
+    Intent intent = new Intent(getCurrentActivity(), AppboyContentCardsActivity.class);
+    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+    this.getReactApplicationContext().startActivity(intent);
+  }
+
+  @ReactMethod
+  public void requestContentCardsRefresh() {
+    Appboy.getInstance(getReactApplicationContext()).requestContentCardsRefresh(false);
+  }
+
+  @ReactMethod
+  public void getContentCards(final Promise promise) {
+    final IEventSubscriber<ContentCardsUpdatedEvent> subscriber = new IEventSubscriber<ContentCardsUpdatedEvent>() {
+      @Override
+      public void trigger(ContentCardsUpdatedEvent event) {
+        promise.resolve(mapContentCards(event.getAllCards()));
+        updateContentCardsIfNeeded(event);
+        Appboy.getInstance(getReactApplicationContext()).removeSingleSubscription(this, ContentCardsUpdatedEvent.class);
+      }
+    };
+    Appboy.getInstance(getReactApplicationContext()).subscribeToContentCardsUpdates(subscriber);
+    Appboy.getInstance(getReactApplicationContext()).requestContentCardsRefresh(true);
+  }
+
+  private WritableArray mapContentCards(List<Card> cardsList) {
+    WritableArray cards = Arguments.createArray();
+    for (Card card : cardsList.toArray(new Card[0])) {
+      cards.pushMap(mapContentCard(card));
+    }
+    return cards;
+  }
+
+  private WritableMap mapContentCard(Card card) {
+    WritableMap mappedCard = Arguments.createMap();
+    mappedCard.putString("id", card.getId());
+    mappedCard.putDouble("created", card.getCreated());
+    mappedCard.putDouble("expiresAt", card.getExpiresAt());
+    mappedCard.putBoolean("viewed", card.getViewed());
+    mappedCard.putBoolean("clicked", card.isClicked());
+    mappedCard.putBoolean("pinned", card.getIsPinned());
+    mappedCard.putBoolean("dismissed", card.isDismissed());
+    mappedCard.putBoolean("dismissible", card.getIsDismissible());
+    mappedCard.putString("url", card.getUrl());
+    mappedCard.putBoolean("openURLInWebView", card.getOpenUriInWebView());
+
+    // Extras
+    WritableMap extras = Arguments.createMap();
+    for (Map.Entry<String, String> entry : card.getExtras().entrySet()) {
+      extras.putString(entry.getKey(), entry.getValue());
+    }
+    mappedCard.putMap("extras", extras);
+
+    // Map according to card type
+    switch (card.getCardType()) {
+      case BANNER:
+        mappedCard.merge(bannerImageCardToWritableMap((BannerImageCard) card));
+        break;
+      case CAPTIONED_IMAGE:
+        mappedCard.merge(captionedImageCardToWritableMap((CaptionedImageCard)card));
+        break;
+      case DEFAULT:
+        break;
+      case SHORT_NEWS:
+        mappedCard.merge(shortNewsCardToWritableMap((ShortNewsCard)card));
+        break;
+      case TEXT_ANNOUNCEMENT:
+        mappedCard.merge(textAnnouncementCardToWritableMap((TextAnnouncementCard)card));
+        break;
+      case CONTROL:
+        break;
+    }
+
+    return mappedCard;
+  }
+
+  private WritableMap captionedImageCardToWritableMap(CaptionedImageCard card) {
+    WritableMap mappedCard = Arguments.createMap();
+    mappedCard.putString("image", card.getImageUrl());
+    mappedCard.putDouble("imageAspectRatio", card.getAspectRatio());
+    mappedCard.putString("title", card.getTitle());
+    mappedCard.putString("cardDescription", card.getDescription());
+    mappedCard.putString("domain", card.getDomain());
+    mappedCard.putString("type", "Captioned");
+    return mappedCard;
+  }
+
+  private WritableMap shortNewsCardToWritableMap(ShortNewsCard card) {
+    WritableMap mappedCard = Arguments.createMap();
+    mappedCard.putString("image", card.getImageUrl());
+    mappedCard.putString("title", card.getTitle());
+    mappedCard.putString("cardDescription", card.getDescription());
+    mappedCard.putString("domain", card.getDomain());
+    mappedCard.putString("type", "Classic");
+    return mappedCard;
+  }
+
+  private WritableMap textAnnouncementCardToWritableMap(TextAnnouncementCard card) {
+    WritableMap mappedCard = Arguments.createMap();
+    mappedCard.putString("title", card.getTitle());
+    mappedCard.putString("cardDescription", card.getDescription());
+    mappedCard.putString("domain", card.getDomain());
+    mappedCard.putString("type", "Classic");
+    return mappedCard;
+  }
+
+  private WritableMap bannerImageCardToWritableMap(BannerImageCard card) {
+    WritableMap mappedCard = Arguments.createMap();
+    mappedCard.putString("image", card.getImageUrl());
+    mappedCard.putDouble("imageAspectRatio", card.getAspectRatio());
+    mappedCard.putString("domain", card.getDomain());
+    mappedCard.putString("type", "Banner");
+    return mappedCard;
+  }
+
+  private void subscribeToContentCardsUpdatedEvent() {
+    Appboy.getInstance(getReactApplicationContext())
+      .removeSingleSubscription(mContentCardsUpdatedSubscriber, ContentCardsUpdatedEvent.class);
+    mContentCardsUpdatedSubscriber = new IEventSubscriber<ContentCardsUpdatedEvent>() {
+      @Override
+      public void trigger(ContentCardsUpdatedEvent event) {
+        boolean updated = event.getLastUpdatedInSecondsFromEpoch() > mContentCardsUpdatedAt;
+        getReactApplicationContext()
+          .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+          .emit(CONTENT_CARDS_UPDATED_EVENT_NAME, updated);
+        updateContentCardsIfNeeded(event);
+      }
+    };
+    Appboy.getInstance(getReactApplicationContext()).subscribeToContentCardsUpdates(mContentCardsUpdatedSubscriber);
+  }
+
+  private void updateContentCardsIfNeeded(ContentCardsUpdatedEvent event) {
+    if (event.getLastUpdatedInSecondsFromEpoch() > mContentCardsUpdatedAt) {
+      mContentCardsUpdatedAt = event.getLastUpdatedInSecondsFromEpoch();
+      mContentCards.clear();
+      mContentCards.addAll(event.getAllCards());
+    }
+  }
+
+  @ReactMethod
+  private void logContentCardsDisplayed() {
+    Appboy.getInstance(getReactApplicationContext()).logContentCardsDisplayed();
+  }
+
+  @ReactMethod
+  private void logContentCardDismissed() {
+    // TODO: is it possible to implement?
+  }
+
+  @ReactMethod
+  private void logContentCardClicked(String id) {
+    Card card = getCardById(id);
+    if (card != null) {
+      card.logClick();
+    }
+  }
+
+  @ReactMethod
+  private void logContentCardImpression(String id) {
+    Card card = getCardById(id);
+    if (card != null) {
+      card.logImpression();
+    }
+  }
+
+  private @Nullable Card getCardById(String id) {
+    for (Card card : mContentCards) {
+      if (card.getId().equals(id)) {
+        return card;
+      }
+    }
+    return null;
+  }
+  // endregion
 }

--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.h
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
-#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-// TODO (Brian) - Modify header/library search paths to be more generic or assume node installation
-@interface AppboyReactBridge : NSObject <RCTBridgeModule>
+// TODO: (Brian) - Modify header/library search paths to be more generic or assume node installation
+@interface AppboyReactBridge : RCTEventEmitter
 
 @end

--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -307,9 +307,9 @@ RCT_EXPORT_METHOD(launchNewsFeed) {
 
 - (void)handleContentCardsUpdated:(NSNotification *)notification {
   BOOL updateIsSuccessful = [notification.userInfo[ABKContentCardsProcessedIsSuccessfulKey] boolValue];
-  if (hasListeners) {
+  if (hasListeners && updateIsSuccessful) {
     RCTLogInfo(@"contentCardsUpdated sent to the bridge");
-    [self sendEventWithName:kContentCardsUpdatedEvent body:@(updateIsSuccessful)];
+    [self sendEventWithName:kContentCardsUpdatedEvent body:kCFNull];
   }
 }
 

--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -309,7 +309,7 @@ RCT_EXPORT_METHOD(launchNewsFeed) {
   BOOL updateIsSuccessful = [notification.userInfo[ABKContentCardsProcessedIsSuccessfulKey] boolValue];
   if (hasListeners && updateIsSuccessful) {
     RCTLogInfo(@"contentCardsUpdated sent to the bridge");
-    [self sendEventWithName:kContentCardsUpdatedEvent body:kCFNull];
+    [self sendEventWithName:kContentCardsUpdatedEvent body:nil];
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -369,6 +369,91 @@ export function launchFeedback(): void;
  */
 export function requestImmediateDataFlush(): void;
 
+// region - Content Cards -
+interface ContentCardType {
+  CLASSIC: 'Classic',
+  BANNER: 'Banner',
+  CAPTIONED: 'Captioned',
+}
+export const ContentCardTypes: ContentCardType;
+
+export interface ContentCard {
+  id: string;
+  created: number;
+  expiresAt: number; // card.expiresAt * 1000 needed?
+  type: ContentCardType;
+  viewed: boolean;
+  clicked: boolean;
+  pinned: boolean;
+  dismissed: boolean;
+  dismissible: boolean;
+  url?: string;
+  openURLInWebView: boolean;
+  extras: { [key: string]: string };
+}
+
+export interface ClassicContentCard extends ContentCard {
+  image?: string;
+  title: string;
+  cardDescription: string;
+  domain?: string;
+}
+
+export interface BannerContentCard extends ContentCard {
+  image: string;
+  imageAspectRatio: number;
+}
+
+export interface CaptionedContentCard extends ContentCard {
+  image: string;
+  imageAspectRatio: number;
+  title: string;
+  cardDescription: string;
+  domain?: string;
+}
+
+/**
+ * Launches the Content Cards UI element.
+ */
+export function launchContentCards(): void;
+
+/**
+ * Requests a refresh of the content cards from Appboy's servers.
+ */
+export function requestContentCardsRefresh(): void;
+
+/**
+ * Manually log a click to Braze for a particular card.
+ * The SDK will only log a card click when the card has the url property with a valid value.
+ * @param {string} id
+ */
+export function logContentCardClicked(id: string): void;
+
+/**
+ * Manually log a dismissal to Braze for a particular card.
+ * @param {string} id
+ */
+export function logContentCardDismissed(id: string): void;
+
+/**
+ * Manually log an impression to Braze for a particular card.
+ * @param {string} id
+ */
+export function logContentCardImpression(id: string): void;
+
+/**
+ * When displaying the Content Cards in your own user interface,
+ * you can manually record Content Cards impressions via the method logContentCardsDisplayed;
+ */
+export function logContentCardsDisplayed(): void;
+
+/**
+ * Returns a content cards array
+ * @returns {Promise<ContentCard[]>}
+ */
+export function getContentCards(): Promise<ContentCard>;
+// endregion
+
 type MonthsAsNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 interface BrazeCardCategory {
@@ -397,6 +482,27 @@ interface NotificationSubscriptionType {
   UNSUBSCRIBED: 'unsubscribed';
 }
 export const NotificationSubscriptionTypes : NotificationSubscriptionType;
+
+// region - Events -
+interface AppboyEvent {
+  CONTENT_CARDS_UPDATED: 'contentCardsUpdated',
+}
+export const AppboyEvents : AppboyEvent;
+
+/**
+ * Subscribes to the specific SDK event
+ * @param {AppboyEvents} event
+ * @param {function} subscriber
+ */
+export function addListener(event: AppboyEvent, subscriber: Function);
+
+/**
+ * Removes subscriptions for the specific SDK event and subscriber
+ * @param {AppboyEvents} event
+ * @param {function} subscriber
+ */
+export function removeSubscription(event: AppboyEvent, subscriber: Function);
+// endregion
 
 type Callback = (error: object, result: object) => void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,22 @@ export function getInitialURL(callback: (deepLink: string) => void): void;
 export function changeUser(userId: string): void;
 
 /**
+ * An alias serves as an alternative unique user identifier. Use aliases to identify users along different
+ *    dimensions than your core user ID:
+ *       * Set a consistent identifier for analytics that will follow a given user both before and after they have
+ *         logged in to a mobile app or website.
+ *       * Add the identifiers used by a third party vendor to your Braze users in order to more easily reconcile
+ *         your data externally.
+ *
+ * Note: Each alias consists of two parts: a name for the identifier itself, and a label indicating the type of
+ *    alias. Users can have multiple aliases with different labels, but only one name per label.
+ *
+ * @param {string} name - An identifier for alias name.
+ * @param {string} label - An identifier for alias label.
+ */
+export function addAlias(name: string, label: string): void;
+
+/**
  * Sets the first name of the user.
  * @param {string} firstName - Limited to 255 characters in length.
  */
@@ -73,6 +89,12 @@ export function setGender(
   gender: GenderTypes[keyof GenderTypes],
   callback?: Callback
 ): void;
+
+/**
+ * Sets the language for the user.
+ * @param {string} language - Should be valid ISO 639-1 language code.
+ */
+export function setLanguage(language: string): void;
 
 /**
  * Sets the country for the user.

--- a/index.d.ts
+++ b/index.d.ts
@@ -451,7 +451,7 @@ export function logContentCardsDisplayed(): void;
  * Returns a content cards array
  * @returns {Promise<ContentCard[]>}
  */
-export function getContentCards(): Promise<ContentCard>;
+export function getContentCards(): Promise<ContentCard[]>;
 // endregion
 
 type MonthsAsNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 // Definitions by: ahanriat <https://github.com/ahanriat>
 // TypeScript Version: 3.0
 
+import { EmitterSubscription } from 'react-native';
+
 /**
  * When launching an iOS application that has previously been force closed, React Native's Linking API doesn't
  * support handling deep links embedded in push notifications. This is due to a race condition on startup between
@@ -494,14 +496,14 @@ export const AppboyEvents : AppboyEvent;
  * @param {AppboyEvents} event
  * @param {function} subscriber
  */
-export function addListener(event: AppboyEvent[keyof AppboyEvent], subscriber: Function);
+export function addListener(event: AppboyEvent[keyof AppboyEvent], subscriber: Function): EmitterSubscription;
 
 /**
  * Removes subscriptions for the specific SDK event and subscriber
  * @param {AppboyEvents} event
  * @param {function} subscriber
  */
-export function removeSubscription(event: AppboyEvent[keyof AppboyEvent], subscriber: Function);
+export function removeSubscription(event: AppboyEvent[keyof AppboyEvent], subscriber: Function): void;
 // endregion
 
 type Callback = (error: object, result: object) => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -494,7 +494,7 @@ export const AppboyEvents : AppboyEvent;
  * @param {AppboyEvents} event
  * @param {function} subscriber
  */
-export function addListener(event: AppboyEvent, subscriber: Function);
+export function addListener(event: AppboyEvent[keyof AppboyEvent], subscriber: Function);
 
 /**
  * Removes subscriptions for the specific SDK event and subscriber

--- a/index.d.ts
+++ b/index.d.ts
@@ -501,7 +501,7 @@ export function addListener(event: AppboyEvent[keyof AppboyEvent], subscriber: F
  * @param {AppboyEvents} event
  * @param {function} subscriber
  */
-export function removeSubscription(event: AppboyEvent, subscriber: Function);
+export function removeSubscription(event: AppboyEvent[keyof AppboyEvent], subscriber: Function);
 // endregion
 
 type Callback = (error: object, result: object) => void;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,12 @@
 const AppboyReactBridge = require('react-native').NativeModules.AppboyReactBridge;
+const Platform = require('react-native').Platform;
+const NativeEventEmitter = require('react-native').NativeEventEmitter;
+const DeviceEventEmitter = require('react-native').DeviceEventEmitter;
+
+const AppBoyEventEmitter = Platform.select({
+  ios: new NativeEventEmitter(AppboyReactBridge),
+  android: DeviceEventEmitter
+});
 
 /**
 * This default callback logs errors and null or false results. AppboyReactBridge methods with callbacks will
@@ -447,14 +455,6 @@ var ReactAppboy = {
     AppboyReactBridge.launchNewsFeed();
   },
 
-  // Content Cards
-  /**
-  * Launches the Content Cards UI element.
-  */
-  launchContentCards: function() {
-    AppboyReactBridge.launchContentCards();
-  },
-
   /**
    * Requests a News Feed refresh.
    */
@@ -544,7 +544,14 @@ var ReactAppboy = {
     callFunctionWithCallback(AppboyReactBridge.setLocationCustomAttribute, [key, latitude, longitude], callback);
   },
 
-  // Refresh Content Cards
+  // region - Content Cards -
+  /**
+   * Launches the Content Cards UI element.
+   */
+  launchContentCards: function() {
+    AppboyReactBridge.launchContentCards();
+  },
+
   /**
   * Requests a refresh of the content cards from Appboy's servers.
   */
@@ -552,15 +559,78 @@ var ReactAppboy = {
     AppboyReactBridge.requestContentCardsRefresh();
   },
 
-  // Dismiss In App Message
+  /**
+   * Returns a content cards array
+   * @returns {Promise<ContentCard[]>}
+   */
+  getContentCards: async function() {
+    return AppboyReactBridge.getContentCards();
+  },
+
+  /**
+   * Manually log a click to Braze for a particular card.
+   * The SDK will only log a card click when the card has the url property with a valid value.
+   * @param {string} id
+   */
+  logContentCardClicked: function(id) {
+    AppboyReactBridge.logContentCardClicked(id);
+  },
+
+  /**
+   * Manually log a dismissal to Braze for a particular card.
+   * @param {string} id
+   */
+  logContentCardDismissed: function(id) {
+    AppboyReactBridge.logContentCardDismissed(id);
+  },
+
+  /**
+   * Manually log an impression to Braze for a particular card.
+   * @param {string} id
+   */
+  logContentCardImpression: function(id) {
+    AppboyReactBridge.logContentCardImpression(id);
+  },
+
+  /**
+   * When displaying the Content Cards in your own user interface,
+   * you can manually record Content Cards impressions via the method logContentCardsDisplayed;
+   */
+  logContentCardsDisplayed: function() {
+    AppboyReactBridge.logContentCardsDisplayed();
+  },
+  // endregion
+
+  // region - In App Messages -
   /**
   * Dismisses the currently displayed in app message.
   */
   hideCurrentInAppMessage: function() {
     AppboyReactBridge.hideCurrentInAppMessage();
   },
+  // endregion
 
-  // Enums
+  // region - Events -
+  /**
+   * Subscribes to the specific SDK event
+   * @param {AppBoyEvents} event
+   * @param {function} subscriber
+   */
+  addListener: function(event, subscriber) {
+    AppBoyEventEmitter.addListener(event, subscriber);
+  },
+
+  /**
+   * Removes subscriptions for the specific SDK event and subscriber
+   * @param {AppBoyEvents} event
+   * @param {function} subscriber
+   */
+  removeSubscription: function(event, subscriber) {
+    AppBoyEventEmitter.removeSubscription(event, subscriber);
+  },
+  // endregion
+
+  // region - Enums -
   CardCategory: {
     'ADVERTISING': 'advertising',
     'ANNOUNCEMENTS': 'announcements',
@@ -568,6 +638,16 @@ var ReactAppboy = {
     'SOCIAL': 'social',
     'NO_CATEGORY': 'no_category',
     'ALL': 'all'
+  },
+
+  ContentCardTypes: {
+    'CLASSIC': 'Classic',
+    'BANNER': 'Banner',
+    'CAPTIONED': 'Captioned'
+  },
+
+  AppBoyEvents: {
+    'CONTENT_CARDS_UPDATED': 'contentCardsUpdated'
   },
 
   NotificationSubscriptionTypes: {
@@ -591,6 +671,7 @@ var ReactAppboy = {
     'MINIMUM_CARD_MARGIN_FOR_IPHONE': 'minimumCardMarginForiPhone',
     'MINIMUM_CARD_MARGIN_FOR_IPAD': 'minimumCardMarginForiPad'
   }
+  // endregion
 };
 
 module.exports = ReactAppboy;

--- a/index.js
+++ b/index.js
@@ -617,7 +617,7 @@ var ReactAppboy = {
    * @param {function} subscriber
    */
   addListener: function(event, subscriber) {
-    AppboyEventEmitter.addListener(event, subscriber);
+    return AppboyEventEmitter.addListener(event, subscriber);
   },
 
   /**

--- a/index.js
+++ b/index.js
@@ -152,12 +152,12 @@ var ReactAppboy = {
   logCustomEvent: function(eventName, eventProperties) {
     AppboyReactBridge.setSDKFlavor();
     for (var key in eventProperties) {
-      if (eventProperties[key] instanceof Date){
+      if (eventProperties[key] instanceof Date) {
         var dateProp = eventProperties[key];
         eventProperties[key] = {
-          type: "UNIX_timestamp",
+          type: 'UNIX_timestamp',
           value: dateProp.valueOf()
-        }
+        };
       }
     }
     AppboyReactBridge.logCustomEvent(eventName, eventProperties);
@@ -189,12 +189,12 @@ var ReactAppboy = {
   */
   logPurchase: function(productId, price, currencyCode, quantity, purchaseProperties) {
     for (var key in purchaseProperties) {
-      if (purchaseProperties[key] instanceof Date){
+      if (purchaseProperties[key] instanceof Date) {
         var dateProp = purchaseProperties[key];
         purchaseProperties[key] = {
-          type: "UNIX_timestamp",
+          type: 'UNIX_timestamp',
           value: dateProp.valueOf()
-        }
+        };
       }
     }
     AppboyReactBridge.logPurchase(productId, price, currencyCode, quantity, purchaseProperties);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const Platform = require('react-native').Platform;
 const NativeEventEmitter = require('react-native').NativeEventEmitter;
 const DeviceEventEmitter = require('react-native').DeviceEventEmitter;
 
-const AppBoyEventEmitter = Platform.select({
+const AppboyEventEmitter = Platform.select({
   ios: new NativeEventEmitter(AppboyReactBridge),
   android: DeviceEventEmitter
 });
@@ -613,20 +613,20 @@ var ReactAppboy = {
   // region - Events -
   /**
    * Subscribes to the specific SDK event
-   * @param {AppBoyEvents} event
+   * @param {AppboyEvents} event
    * @param {function} subscriber
    */
   addListener: function(event, subscriber) {
-    AppBoyEventEmitter.addListener(event, subscriber);
+    AppboyEventEmitter.addListener(event, subscriber);
   },
 
   /**
    * Removes subscriptions for the specific SDK event and subscriber
-   * @param {AppBoyEvents} event
+   * @param {AppboyEvents} event
    * @param {function} subscriber
    */
   removeSubscription: function(event, subscriber) {
-    AppBoyEventEmitter.removeSubscription(event, subscriber);
+    AppboyEventEmitter.removeSubscription(event, subscriber);
   },
   // endregion
 
@@ -646,7 +646,7 @@ var ReactAppboy = {
     'CAPTIONED': 'Captioned'
   },
 
-  AppBoyEvents: {
+  AppboyEvents: {
     'CONTENT_CARDS_UPDATED': 'contentCardsUpdated'
   },
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/Appboy/appboy-react-sdk#readme",
   "devDependencies": {
+    "@types/react-native": "^0.57.65",
     "eslint": "^3.4.0",
     "eslint-config-standard": "^6.0.0",
     "eslint-config-standard-jsx": "^3.0.0",


### PR DESCRIPTION
I have written an initial version of a bridge that provides a base method to implement custom content card UI using react native components.

I went with promise-based implementation, as I don't think callbacks are convenient to use.

I have also decided to send only the 'update succeed' event to the bridge as it is a costly operation.

I'm doing initial testing now and need some feedback on the codebase (testing help is also appreciated).

In the meantime, appboy-react-sdk requires technical polishing and it may be useful to decouple bridge classes to smaller modules such as `ContentCardsModule`, `NewsFeedModule`, `AnalyticsModule`, etc.