### PR TITLE
Fixed crash: access JS before React set up

### DIFF
--- a/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
+++ b/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
@@ -539,7 +539,11 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
       public void trigger(ContentCardsUpdatedEvent event) {
         boolean updated = event.getLastUpdatedInSecondsFromEpoch() > mContentCardsUpdatedAt;
         if (updated) {
-          getReactApplicationContext()
+          ReactApplicationContext reactContext = getReactApplicationContext();
+          if (!reactContext.hasActiveCatalystInstance()) {
+            return;
+          }
+          reactContext
                   .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                   .emit(CONTENT_CARDS_UPDATED_EVENT_NAME, updated);
         }


### PR DESCRIPTION
- java.lang.RuntimeException: Tried to access a JS module before the React instance was fully set up. Calls to ReactContext#getJSModule should only happen once initialize() has been called on your native module.