### PR TITLE
Close Content Card iOS code

### DIFF
--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -351,6 +351,19 @@ RCT_REMAP_METHOD(getContentCards, getContentCardsWithResolver:(RCTPromiseResolve
   resolve([self getMappedContentCards]);
 }
 
+RCT_REMAP_METHOD(closeContentCard, closeContentCardWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  RCTLogInfo(@"closeContentCard called");
+  UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+  UIViewController *mainViewController = keyWindow.rootViewController;
+  if ([mainViewController.presentedViewController isKindOfClass:[ABKContentCardsViewController class]]){
+      [(ABKContentCardsViewController*)mainViewController.presentedViewController dismissViewControllerAnimated:YES completion: ^() {
+          resolve(nil);
+      }];
+  } else {
+      reject(@"not_open", @"The content card is not open", nil);
+  }
+}
+
 RCT_EXPORT_METHOD(logContentCardClicked:(NSString *)idString) {
   ABKContentCard *cardToClick = [self getContentCardById:idString];
   if (cardToClick) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -388,6 +388,11 @@ export interface CaptionedContentCard extends ContentCard {
 export function launchContentCards(): void;
 
 /**
+ * Closes the Content Card UI element.
+ */
+export function closeContentCard(): Promise<void>;
+
+/**
  * Requests a refresh of the content cards from Appboy's servers.
  */
 export function requestContentCardsRefresh(): void;

--- a/index.js
+++ b/index.js
@@ -455,6 +455,13 @@ var ReactAppboy = {
   },
 
   /**
+  * Closes the News Feed UI element.
+  */
+  closeContentCard: function() {
+  return AppboyReactBridge.closeContentCard();
+  },
+
+  /**
    * Returns a content cards array
    * @returns {Promise<ContentCard[]>}
    */


### PR DESCRIPTION
Close Content Card iOS code, This is very important to close the modal on ios when the user press on a content card attached with deep links. Kindly review and merge it, please.