### PR TITLE
chore: explicitly add Java 8 declaration for compileOptions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,6 +14,11 @@ android {
     versionCode 1
     versionName '1.0'
   }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Hi there,

Opening this PR in order to fix the issue #118, with the solution proposed by @radixdev on [this comment](https://github.com/Appboy/appboy-react-sdk/issues/118#issuecomment-876731054) :)

Fixes #118 