### PR TITLE
Add pushAuthorizationFromUserNotificationCenter method

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -17,6 +17,7 @@ jest.mock('NativeEventEmitter');
 jest.mock('NativeModules', () => {
   return {
     AppboyReactBridge: {
+      pushAuthorizationFromUserNotificationCenter: jest.fn(),
       registerAndroidPushToken: jest.fn(),
       setGoogleAdvertisingId: jest.fn(),
       setFirstName: jest.fn(),
@@ -86,6 +87,12 @@ const testInAppMessageJson = `{\"message\":\"body body\",\"type\":\"MODAL\",\"te
 
 afterEach(() => {
   jest.clearAllMocks();
+});
+
+test('it calls AppboyReactBridge.pushAuthorizationFromUserNotificationCenter', () => {
+  const pushAuthGranted = true;
+  ReactAppboy.pushAuthorizationFromUserNotificationCenter(pushAuthGranted);
+  expect(NativeModules.AppboyReactBridge.pushAuthorizationFromUserNotificationCenter).toBeCalledWith(pushAuthGranted);
 });
 
 test('it calls AppboyReactBridge.registerAndroidPushToken', () => {

--- a/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
+++ b/android/src/main/java/com/appboy/reactbridge/AppboyReactBridge.java
@@ -127,6 +127,12 @@ public class AppboyReactBridge extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void pushAuthorizationFromUserNotificationCenter(boolean pushAuthGranted) {
+    // Dummy method required for the iOS SDK flavor implementation; see AppboyReactBridge.pushAuthorizationFromUserNotificationCenter()
+    // in index.js. The Android bridge does not need this.
+  }
+
+  @ReactMethod
   public void registerAndroidPushToken(String token) {
     Braze.getInstance(getReactApplicationContext()).registerAppboyPushMessages(token);
   }

--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -103,6 +103,12 @@ RCT_EXPORT_METHOD(addAlias:(NSString *)aliasName withLabel:(NSString *)aliasLabe
   [[Appboy sharedInstance].user addAlias:aliasName withLabel:aliasLabel];
 }
 
+RCT_EXPORT_METHOD(pushAuthorizationFromUserNotificationCenter:(BOOL)pushAuthGranted) 
+{
+  RCTLogInfo(@"[Appboy sharedInstance] pushAuthorizationFromUserNotificationCenter");
+  [[Appboy sharedInstance] pushAuthorizationFromUserNotificationCenter:pushAuthGranted];
+}
+
 RCT_EXPORT_METHOD(registerAndroidPushToken:(NSString *)token)
 {
   RCTLogInfo(@"Warning: This is an Android only feature.");

--- a/index.d.ts
+++ b/index.d.ts
@@ -151,6 +151,15 @@ export function setAvatarImageUrl(avatarImageUrl: string): void;
 export function setDateOfBirth(year: number, month: MonthsAsNumber, day: number): void;
 
 /**
+ * This method pots the current device's push authorization status to Braze server.
+ * 
+ * iOS only.
+ * 
+ * @param {boolean} pushAuthGranted - If the permission is granted or not.
+ */
+export function pushAuthorizationFromUserNotificationCenter(pushAuthGranted: boolean): void;
+
+/**
  * This method posts a token to Appboy's servers to associate the token with the current device.
  *
  * No-op on iOS.

--- a/index.js
+++ b/index.js
@@ -180,6 +180,17 @@ var ReactAppboy = {
   },
 
   /**
+   * This method pots the current device's push authorization status to Braze server.
+   * 
+   * iOS only.
+   * 
+   * @param {boolean} pushAuthGranted - If the permission is granted or not.
+   */
+  pushAuthorizationFromUserNotificationCenter: function(pushAuthGranted) {
+    AppboyReactBridge.pushAuthorizationFromUserNotificationCenter(pushAuthGranted);
+  },
+
+  /**
   * This method posts a token to Appboy's servers to associate the token with the current device.
   *
   * No-op on iOS.


### PR DESCRIPTION
This PR adds pushAuthorizationFromUserNotificationCenter method to send the permission status to Braze server.
Related to https://github.com/Appboy/appboy-react-sdk/issues/95#issuecomment-754955311

As most of React Native apps should trigger push permission dialog from the JavaScript side, and native module tells the result to RN, it seems to be very helpful to have this method exported to JavaScript side. 