### PR TITLE
Start SDK from RN context

### DIFF
--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -521,6 +521,11 @@ RCT_EXPORT_METHOD(enableSDK) {
   [Appboy requestEnableSDKOnNextAppRun];
 }
 
+RCT_EXPORT_METHOD(startWithApiKey:(NSString *)brazeKey withLaunchOptions:(nullable NSDictionary *)launchOptions) {
+	UIApplication *application = [UIApplication sharedApplication];
+	[Appboy startWithApiKey:brazeKey inApplication:application withLaunchOptions:launchOptions];
+}
+
 RCT_EXPORT_METHOD(requestLocationInitialization) {
   RCTLogInfo(@"Warning: This is an Android only feature.");
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -511,6 +511,11 @@ export function disableSDK(): void;
 export function enableSDK(): void;
 
 /**
+ * Starts the Braze SDK.
+ */
+ export function startWithApiKey(apiKey: string, options: Record<string, string> | undefined): void;
+
+/**
  * Call this method once a user grants location permissions on Android
  * to initialize Braze location features. Calling this method is a no-op on
  * iOS.

--- a/index.js
+++ b/index.js
@@ -620,6 +620,13 @@ var ReactAppboy = {
   },
 
   /**
+  * Starts the Braze SDK with an API key
+  */
+   startWithApiKey: function(apiKey, options) {
+    AppboyReactBridge.startWithApiKey(apiKey, options);
+  },
+
+  /**
   * Call this method once a user grants location permissions on Android
   * to initialize Braze location features. Calling this method is a no-op on
   * iOS.


### PR DESCRIPTION
Applications built in React Native should have the ability to determine when Braze (aka Appboy) starts to collect information and count as an MAU. For our specific instance, we only want to store data for MAUs that have authenticated. To do so, we must only register the app with Braze when a user has authenticated.

This is a work in progress and currently only supports iOS. The approach for Android seems a bit less obvious as Braze is managed by the `ActivityLifecycleCallbacks`. Would appreciate the teams input on this ASAP as we'd like to reduce our current MAUs as we're not using the anon data.

One outstanding question:
- Could there be any issues with storing push tokens with the change to the SDK lifecycle?