### PR TITLE
use union for content card types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -382,11 +382,10 @@ interface ContentCardType {
 }
 export const ContentCardTypes: ContentCardType;
 
-export interface ContentCard {
+export interface ContentCardBase {
   id: string;
   created: number;
   expiresAt: number;
-  type: ContentCardType[keyof ContentCardType];
   viewed: boolean;
   clicked: boolean;
   pinned: boolean;
@@ -397,25 +396,30 @@ export interface ContentCard {
   extras: { [key: string]: string };
 }
 
-export interface ClassicContentCard extends ContentCard {
+export interface ClassicContentCard extends ContentCardBase {
+  type: 'Classic';
   image?: string;
   title: string;
   cardDescription: string;
   domain?: string;
 }
 
-export interface BannerContentCard extends ContentCard {
+export interface BannerContentCard extends ContentCardBase {
+  type: 'Banner';
   image: string;
   imageAspectRatio: number;
 }
 
-export interface CaptionedContentCard extends ContentCard {
+export interface CaptionedContentCard extends ContentCardBase {
+  type: 'Captioned';
   image: string;
   imageAspectRatio: number;
   title: string;
   cardDescription: string;
   domain?: string;
 }
+
+export type ContentCard = ClassicContentCard | BannerContentCard | CaptionedContentCard;
 
 /**
  * Launches the Content Cards UI element.


### PR DESCRIPTION
This is the fixes to the ContentCard types so that when using .getContentCards() the additional fields based on the type of card can be used without a type error. 