### PR TITLE
feat: add native permission handling for iOS

### DIFF
--- a/AppboyProject/AppboyProject.js
+++ b/AppboyProject/AppboyProject.js
@@ -1,5 +1,5 @@
 'use strict';
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import {
   StyleSheet,
   Text,
@@ -11,7 +11,7 @@ import {
   Alert,
   TextInput,
   Platform,
-  DeviceEventEmitter,
+  DeviceEventEmitter
 } from 'react-native';
 
 const ReactAppboy = require('react-native-appboy-sdk');
@@ -20,62 +20,44 @@ class AppboyProject extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      userIdText: '',
+      userIdText : '',
       signatureText: '',
-      customEventText: '',
-      subscriptionState: 's',
-      gender: 'm',
+      customEventText : '',
+      subscriptionState : 's',
+      gender : 'm',
       message: 'Success',
-      toastVisible: 0,
+      toastVisible: 0
     };
     this._getInstallTrackingId = this._getInstallTrackingId.bind(this);
     this._updateCardCount = this._updateCardCount.bind(this);
     this._changeUserPress = this._changeUserPress.bind(this);
     this._setSignaturePress = this._setSignaturePress.bind(this);
     this._logCustomEventPress = this._logCustomEventPress.bind(this);
-    this._setSubscriptionStatePress = this._setSubscriptionStatePress.bind(
-      this,
-    );
+    this._setSubscriptionStatePress = this._setSubscriptionStatePress.bind(this);
     this._logPurchasePress = this._logPurchasePress.bind(this);
     this._setLanguagePress = this._setLanguagePress.bind(this);
     this._logCustomAttributePress = this._logCustomAttributePress.bind(this);
     this._logUserPropertiesPress = this._logUserPropertiesPress.bind(this);
-    this._unsetCustomUserAttributePress = this._unsetCustomUserAttributePress.bind(
-      this,
-    );
-    this._addToCustomAttributeArrayPress = this._addToCustomAttributeArrayPress.bind(
-      this,
-    );
-    this._removeFromCustomAttributeArrayPress = this._removeFromCustomAttributeArrayPress.bind(
-      this,
-    );
-    this._incrementCustomAttributePress = this._incrementCustomAttributePress.bind(
-      this,
-    );
+    this._unsetCustomUserAttributePress = this._unsetCustomUserAttributePress.bind(this);
+    this._addToCustomAttributeArrayPress = this._addToCustomAttributeArrayPress.bind(this);
+    this._removeFromCustomAttributeArrayPress = this._removeFromCustomAttributeArrayPress.bind(this);
+    this._incrementCustomAttributePress = this._incrementCustomAttributePress.bind(this);
     this._setTwitterData = this._setTwitterData.bind(this);
     this._setFacebookData = this._setFacebookData.bind(this);
     this._requestFeedRefresh = this._requestFeedRefresh.bind(this);
-    this._requestImmediateDataFlush = this._requestImmediateDataFlush.bind(
-      this,
-    );
+    this._requestImmediateDataFlush = this._requestImmediateDataFlush.bind(this);
     this._wipeData = this._wipeData.bind(this);
     this._disableSDK = this._disableSDK.bind(this);
     this._enableSDK = this._enableSDK.bind(this);
-    this._requestPermission = this._requestPermission.bind(this);
-    this._requestLocationInitialization = this._requestLocationInitialization.bind(
-      this,
-    );
+    this._requestLocationInitialization = this._requestLocationInitialization.bind(this);
     this._requestGeofences = this._requestGeofences.bind(this);
-    this._setLocationCustomAttribute = this._setLocationCustomAttribute.bind(
-      this,
-    );
+    this._setLocationCustomAttribute = this._setLocationCustomAttribute.bind(this);
     this._setGenderPress = this._setGenderPress.bind(this);
-    this._requestContentCardsRefresh = this._requestContentCardsRefresh.bind(
-      this,
-    );
+    this._requestContentCardsRefresh = this._requestContentCardsRefresh.bind(this);
     this._hideCurrentInAppMessage = this._hideCurrentInAppMessage.bind(this);
     this._setAttributionData = this._setAttributionData.bind(this);
     this._getContentCards = this._getContentCards.bind(this);
+    this._requestPermission = this._requestPermission.bind(this);
   }
 
   componentDidMount() {
@@ -86,15 +68,13 @@ class AppboyProject extends Component {
 
     // No `url` event is triggered on application start, so this handles
     // the case where a deep link launches the application
-    Linking.getInitialURL()
-      .then(url => {
-        if (url) {
-          console.log('Linking.getInitialURL is ' + url);
-          this._showToast('Linking.getInitialURL is ' + url);
-          this._handleOpenUrl({url});
-        }
-      })
-      .catch(err => console.error('Error getting initial URL', err));
+    Linking.getInitialURL().then((url) => {
+      if (url) {
+        console.log('Linking.getInitialURL is ' + url);
+        this._showToast('Linking.getInitialURL is ' + url);
+        this._handleOpenUrl({url});
+      }
+    }).catch(err => console.error('Error getting initial URL', err));
 
     // Handles deep links when an iOS app is launched from hard close via push click.
     // Note that this isn't handled by Linking.getInitialURL(), as the app is
@@ -109,37 +89,22 @@ class AppboyProject extends Component {
       }
     });
 
-    ReactAppboy.addListener(
-      ReactAppboy.Events.CONTENT_CARDS_UPDATED,
-      function() {
-        console.log('Content Cards Updated.');
-      },
-    );
+    ReactAppboy.addListener(ReactAppboy.Events.CONTENT_CARDS_UPDATED, function() {
+      console.log('Content Cards Updated.');
+    });
 
-    ReactAppboy.addListener(
-      ReactAppboy.Events.SDK_AUTHENTICATION_ERROR,
-      function(data) {
-        console.log(
-          `SDK Authentication for ${data.user_id} failed with error code ${
-            data.error_code
-          }.`,
-        );
-      },
-    );
+    ReactAppboy.addListener(ReactAppboy.Events.SDK_AUTHENTICATION_ERROR, function(data) {
+      console.log(`SDK Authentication for ${data.user_id} failed with error code ${data.error_code}.`);
+    });
 
-    this._listener = DeviceEventEmitter.addListener(
-      'inAppMessageReceived',
-      function(event) {
-        let inAppMessage = new ReactAppboy.BrazeInAppMessage(
-          event.inAppMessage,
-        );
-        ReactAppboy.logInAppMessageClicked(inAppMessage);
-        ReactAppboy.logInAppMessageImpression(inAppMessage);
-        ReactAppboy.logInAppMessageButtonClicked(inAppMessage, 0);
-        that._showToast('inAppMessage received in the React layer');
-        console.log(inAppMessage);
-      },
-    );
+    this._listener = DeviceEventEmitter.addListener("inAppMessageReceived", function(event) {
+      let inAppMessage = new ReactAppboy.BrazeInAppMessage(event.inAppMessage);
+      ReactAppboy.logInAppMessageClicked(inAppMessage);
+      ReactAppboy.logInAppMessageImpression(inAppMessage);
+      ReactAppboy.logInAppMessageButtonClicked(inAppMessage, 0);
+      that._showToast('inAppMessage received in the React layer');
+      console.log(inAppMessage);
+    })
   }
 
   componentWillUnmount() {
@@ -149,32 +114,30 @@ class AppboyProject extends Component {
 
   _handleOpenUrl(event) {
     console.log('handleOpenUrl called on url ' + event.url);
-    Alert.alert('Deep Link', event.url, [
-      {text: 'OK', onPress: () => console.log('OK Pressed')},
-    ]);
+    Alert.alert(
+      'Deep Link',
+      event.url,
+      [
+        {text: 'OK', onPress: () => console.log('OK Pressed')}
+      ]
+    );
   }
 
   _updateCardCount() {
-    ReactAppboy.getUnreadCardCountForCategories(
-      ReactAppboy.CardCategory.ALL,
-      (err, res) => {
-        if (err) {
-          console.log('getUnreadCardCountForCategories returned error ' + err);
-        } else if (res != null) {
-          this.setState({unreadCardCount: res});
-        }
-      },
-    );
-    ReactAppboy.getCardCountForCategories(
-      ReactAppboy.CardCategory.ALL,
-      (err, res) => {
-        if (err) {
-          console.log('getCardCountForCategories returned error ' + err);
-        } else if (res != null) {
-          this.setState({cardCount: res});
-        }
-      },
-    );
+    ReactAppboy.getUnreadCardCountForCategories(ReactAppboy.CardCategory.ALL, (err, res) => {
+      if (err) {
+        console.log('getUnreadCardCountForCategories returned error ' + err);
+      } else if (res != null) {
+        this.setState({unreadCardCount: res});
+      }
+    });
+    ReactAppboy.getCardCountForCategories(ReactAppboy.CardCategory.ALL, (err, res) => {
+      if (err) {
+        console.log('getCardCountForCategories returned error ' + err);
+      } else if (res != null) {
+        this.setState({cardCount: res});
+      }
+    });
   }
 
   async _requestPermission() {
@@ -187,57 +150,67 @@ class AppboyProject extends Component {
       <ScrollView
         contentContainerStyle={styles.container}
         stickyHeaderIndices={[0]}>
-        <View style={[styles.toastView, {opacity: this.state.toastVisible}]}>
-          <Text style={styles.toastText}>{this.state.message}</Text>
+        <View
+          style={[styles.toastView, {opacity: this.state.toastVisible}]}>
+          <Text
+            style={styles.toastText}>
+            {this.state.message}
+          </Text>
         </View>
         <View style={styles.row}>
           <TextInput
             style={styles.textInput}
-            onChangeText={userIdText => this.setState({userIdText})}
+            onChangeText={(userIdText) => this.setState({userIdText})}
             value={this.state.userIdText}
-          />
-          <TouchableHighlight onPress={this._changeUserPress}>
+            />
+          <TouchableHighlight
+            onPress={this._changeUserPress}>
             <Text>Set User ID</Text>
           </TouchableHighlight>
         </View>
         <View style={styles.row}>
           <TextInput
             style={styles.textInput}
-            onChangeText={signatureText => this.setState({signatureText})}
+            onChangeText={(signatureText) => this.setState({signatureText})}
             value={this.state.signatureText}
-          />
-          <TouchableHighlight onPress={this._setSignaturePress}>
+            />
+          <TouchableHighlight
+            onPress={this._setSignaturePress}>
             <Text>Set Signature</Text>
           </TouchableHighlight>
         </View>
         <View style={styles.row}>
           <TextInput
             style={styles.textInput}
-            onChangeText={customEventText => this.setState({customEventText})}
-          />
-          <TouchableHighlight onPress={this._logCustomEventPress}>
+            onChangeText={(customEventText) => this.setState({customEventText})}/>
+          <TouchableHighlight
+            onPress={this._logCustomEventPress}>
             <Text>Log Custom Event</Text>
           </TouchableHighlight>
         </View>
         <View style={styles.row}>
           <TextInput
             style={styles.textInput}
-            onChangeText={languageText => this.setState({languageText})}
-          />
-          <TouchableHighlight onPress={this._setLanguagePress}>
+            onChangeText={(languageText) => this.setState({languageText})}/>
+          <TouchableHighlight
+            onPress={this._setLanguagePress}>
             <Text>Set Language</Text>
           </TouchableHighlight>
         </View>
-        <TouchableHighlight onPress={this._logPurchasePress}>
+        <TouchableHighlight
+          onPress={this._logPurchasePress}>
           <Text>Log Purchase</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._logCustomAttributePress}>
+        <TouchableHighlight
+          onPress={this._logCustomAttributePress}>
           <Text>Set Custom User Attributes</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._logUserPropertiesPress}>
+        <TouchableHighlight
+          onPress={this._logUserPropertiesPress}>
           <Text>Set User Properties</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._hideCurrentInAppMessage}>
+        <TouchableHighlight
+          onPress={this._hideCurrentInAppMessage}>
           <Text>Dismiss In App Message</Text>
         </TouchableHighlight>
         <View style={styles.row}>
@@ -245,12 +218,13 @@ class AppboyProject extends Component {
             style={styles.picker}
             itemStyle={{fontSize: 16}}
             selectedValue={this.state.subscriptionState}
-            onValueChange={value => this.setState({subscriptionState: value})}>
-            <Picker.Item label="Subscribed" value="s" />
-            <Picker.Item label="Unsubscribed" value="u" />
-            <Picker.Item label="Opted-in" value="o" />
+            onValueChange={(value) => this.setState({subscriptionState: value})}>
+            <Picker.Item label='Subscribed' value='s' />
+            <Picker.Item label='Unsubscribed' value='u' />
+            <Picker.Item label='Opted-in' value='o' />
           </Picker>
-          <TouchableHighlight onPress={this._setSubscriptionStatePress}>
+          <TouchableHighlight
+            onPress={this._setSubscriptionStatePress}>
             <Text>Set Subscription State</Text>
           </TouchableHighlight>
         </View>
@@ -259,103 +233,120 @@ class AppboyProject extends Component {
             style={styles.picker}
             itemStyle={{fontSize: 16}}
             selectedValue={this.state.gender}
-            onValueChange={value => this.setState({gender: value})}>
-            <Picker.Item label="Female" value="f" />
-            <Picker.Item label="Male" value="m" />
-            <Picker.Item label="Not Applicable" value="n" />
-            <Picker.Item label="Other" value="o" />
-            <Picker.Item label="Prefer Not to Say" value="p" />
-            <Picker.Item label="Unknown" value="u" />
+            onValueChange={(value) => this.setState({gender: value})}>
+            <Picker.Item label='Female' value='f' />
+            <Picker.Item label='Male' value='m' />
+            <Picker.Item label='Not Applicable' value='n' />
+            <Picker.Item label='Other' value='o' />
+            <Picker.Item label='Prefer Not to Say' value='p' />
+            <Picker.Item label='Unknown' value='u' />
           </Picker>
-          <TouchableHighlight onPress={this._setGenderPress}>
+          <TouchableHighlight
+            onPress={this._setGenderPress}>
             <Text>Set Gender</Text>
           </TouchableHighlight>
         </View>
-        <TouchableHighlight onPress={this._unsetCustomUserAttributePress}>
+        <TouchableHighlight
+          onPress={this._requestPermission}>
+          <Text>Request notification permission (iOS)</Text>
+        </TouchableHighlight>
+        <TouchableHighlight
+          onPress={this._unsetCustomUserAttributePress}>
           <Text>Unset Custom User Attributes</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._addToCustomAttributeArrayPress}>
+        <TouchableHighlight
+          onPress={this._addToCustomAttributeArrayPress}>
           <Text>Add to Custom Attribute Array</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._removeFromCustomAttributeArrayPress}>
+        <TouchableHighlight
+          onPress={this._removeFromCustomAttributeArrayPress}>
           <Text>Remove From Custom Attribute Array</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._incrementCustomAttributePress}>
+        <TouchableHighlight
+          onPress={this._incrementCustomAttributePress}>
           <Text>Increment Custom Attribute Array</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._setTwitterData}>
+        <TouchableHighlight
+          onPress={this._setTwitterData}>
           <Text>Set Twitter Data</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._setFacebookData}>
+        <TouchableHighlight
+          onPress={this._setFacebookData}>
           <Text>Set Facebook Data</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._launchNewsFeedPress}>
+        <TouchableHighlight
+          onPress={this._launchNewsFeedPress}>
           <Text>Launch News Feed</Text>
         </TouchableHighlight>
         <TouchableHighlight onPress={this._updateCardCount}>
-          <Text>
-            Unread Cards (Click to Refresh): {this.state.unreadCardCount} /{' '}
-            {this.state.cardCount}
-          </Text>
+          <Text>Unread Cards (Click to Refresh): {this.state.unreadCardCount} / {this.state.cardCount}</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._requestFeedRefresh}>
+        <TouchableHighlight
+          onPress={this._requestFeedRefresh}>
           <Text>Request Feed Refresh</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._launchContentCardsPress}>
+        <TouchableHighlight
+          onPress={this._launchContentCardsPress}>
           <Text>Launch Content Cards</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._requestContentCardsRefresh}>
+        <TouchableHighlight
+          onPress={this._requestContentCardsRefresh}>
           <Text>Request Content Cards Refresh</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._requestImmediateDataFlush}>
+        <TouchableHighlight
+          onPress={this._requestImmediateDataFlush}>
           <Text>Request Immediate Data Flush</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._wipeData}>
+        <TouchableHighlight
+          onPress={this._wipeData}>
           <Text>Wipe Data</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._disableSDK}>
+        <TouchableHighlight
+          onPress={this._disableSDK}>
           <Text>Disable SDK</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._enableSDK}>
+        <TouchableHighlight
+          onPress={this._enableSDK}>
           <Text>Enable SDK</Text>
         </TouchableHighlight>
-        {Platform.OS === 'android' ? (
-          <TouchableHighlight onPress={this._requestLocationInitialization}>
-            <Text>Request Location Initialization</Text>
-          </TouchableHighlight>
-        ) : (
-          false
-        )}
-        <TouchableHighlight onPress={this._requestGeofences}>
+        { Platform.OS === 'android' ?
+        <TouchableHighlight
+          onPress={this._requestLocationInitialization}>
+          <Text>Request Location Initialization</Text>
+        </TouchableHighlight>
+        : false }
+        <TouchableHighlight
+          onPress={this._requestGeofences}>
           <Text>Request Geofences</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._setLocationCustomAttribute}>
+        <TouchableHighlight
+          onPress={this._setLocationCustomAttribute}>
           <Text>Set Custom Location Attribute</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._setAttributionData}>
+        <TouchableHighlight
+          onPress={this._setAttributionData}>
           <Text>Set Attribution Data</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._getInstallTrackingId}>
+        <TouchableHighlight
+          onPress={this._getInstallTrackingId}>
           <Text>Get Install Tracking ID</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._getContentCards}>
+        <TouchableHighlight
+          onPress={this._getContentCards}>
           <Text>Request Cached Content Cards</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._requestPermission}>
-          <Text>Request permission ios</Text>
-        </TouchableHighlight>
-      </ScrollView>
+        </ScrollView>
     );
   }
   _showToast(message) {
-    this.setState({message: message});
+    this.setState({ message: message });
     this.setState({toastVisible: 1}, this._hideToast);
   }
   _hideToast() {
     setTimeout(() => {
-      this.setState({message: 'Success'});
+      this.setState({ message: 'Success' });
       this.setState({toastVisible: 0});
-    }, 1000);
+    }, 1000)
   }
   _changeUserPress(event) {
     ReactAppboy.changeUser(this.state.userIdText);
@@ -367,29 +358,9 @@ class AppboyProject extends Component {
   }
   _logCustomEventPress(event) {
     var testDate = new Date();
-    ReactAppboy.logCustomEvent(this.state.customEventText, {
-      stringKey: 'stringValue',
-      intKey: 42,
-      floatKey: 1.23,
-      boolKey: true,
-      dateKey: testDate,
-    });
+    ReactAppboy.logCustomEvent(this.state.customEventText, {'stringKey': 'stringValue', 'intKey': 42, 'floatKey': 1.23, 'boolKey': true, 'dateKey': testDate});
     ReactAppboy.logCustomEvent(this.state.customEventText + 'NoProps');
-    ReactAppboy.logCustomEvent(this.state.customEventText, {
-      arrayKey: [
-        'arrayVal1',
-        'arrayVal2',
-        testDate,
-        [testDate, 'nestedArrayval'],
-        {dictInArrayKey: testDate},
-      ],
-      dictKey: {
-        dictKey1: 'dictVal1',
-        dictKey2: testDate,
-        dictKey3: {nestedDictKey1: testDate},
-        dictKey4: ['nestedArrayVal1', 'nestedArrayVal2'],
-      },
-    });
+    ReactAppboy.logCustomEvent(this.state.customEventText, {'arrayKey': ['arrayVal1', 'arrayVal2', testDate, [testDate, 'nestedArrayval'], {'dictInArrayKey': testDate}], 'dictKey': {'dictKey1': 'dictVal1', 'dictKey2': testDate, 'dictKey3': {'nestedDictKey1': testDate}, 'dictKey4': ['nestedArrayVal1', 'nestedArrayVal2']}});
     this._showToast('Event logged: ' + this.state.customEventText);
   }
   _setLanguagePress(event) {
@@ -397,74 +368,47 @@ class AppboyProject extends Component {
     this._showToast('Language changed to: ' + this.state.languageText);
   }
   _setSubscriptionStatePress(event) {
-    console.log(
-      'Received request to change subscription state for email and push to ' +
-        this.state.subscriptionState,
-    );
+    console.log('Received request to change subscription state for email and push to ' + this.state.subscriptionState);
     if (this.state.subscriptionState == 'o') {
-      ReactAppboy.setEmailNotificationSubscriptionType(
-        ReactAppboy.NotificationSubscriptionTypes.OPTED_IN,
-      );
-      ReactAppboy.setPushNotificationSubscriptionType(
-        ReactAppboy.NotificationSubscriptionTypes.OPTED_IN,
-      );
+      ReactAppboy.setEmailNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.OPTED_IN);
+      ReactAppboy.setPushNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.OPTED_IN);
       this._showToast('User opted in to Email & Push');
     } else if (this.state.subscriptionState == 'u') {
-      ReactAppboy.setEmailNotificationSubscriptionType(
-        ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED,
-      );
-      ReactAppboy.setPushNotificationSubscriptionType(
-        ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED,
-      );
+      ReactAppboy.setEmailNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED);
+      ReactAppboy.setPushNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED);
       this._showToast('User unsubscribed from Email & Push');
     } else if (this.state.subscriptionState == 's') {
-      ReactAppboy.setEmailNotificationSubscriptionType(
-        ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED,
-      );
-      ReactAppboy.setPushNotificationSubscriptionType(
-        ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED,
-      );
+      ReactAppboy.setEmailNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED);
+      ReactAppboy.setPushNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED);
       this._showToast('User subscribed to Email & Push');
     }
   }
   _setGenderPress(event) {
     console.log('Received request to change gender to ' + this.state.gender);
     if (this.state.gender == 'f') {
-      ReactAppboy.setGender(ReactAppboy.Genders.FEMALE);
+      ReactAppboy.setGender(ReactAppboy.Genders.FEMALE)
       this._showToast('User gender set to "female"');
     } else if (this.state.gender == 'm') {
-      ReactAppboy.setGender(ReactAppboy.Genders.MALE);
+      ReactAppboy.setGender(ReactAppboy.Genders.MALE)
       this._showToast('User gender set to "male"');
-    } else if (this.state.gender == 'n') {
-      ReactAppboy.setGender(ReactAppboy.Genders.NOT_APPLICABLE);
+    }  else if (this.state.gender == 'n') {
+      ReactAppboy.setGender(ReactAppboy.Genders.NOT_APPLICABLE)
       this._showToast('User gender set to "not applicable"');
     } else if (this.state.gender == 'o') {
-      ReactAppboy.setGender(ReactAppboy.Genders.OTHER);
+      ReactAppboy.setGender(ReactAppboy.Genders.OTHER)
       this._showToast('User gender set to "other"');
     } else if (this.state.gender == 'p') {
-      ReactAppboy.setGender(ReactAppboy.Genders.PREFER_NOT_TO_SAY);
+      ReactAppboy.setGender(ReactAppboy.Genders.PREFER_NOT_TO_SAY)
       this._showToast('User gender set to "prefer not to say"');
     } else if (this.state.gender == 'u') {
-      ReactAppboy.setGender(ReactAppboy.Genders.UNKNOWN);
+      ReactAppboy.setGender(ReactAppboy.Genders.UNKNOWN)
       this._showToast('User gender set to "unknown"');
     }
   }
   _logPurchasePress(event) {
     var testDate = new Date();
-    ReactAppboy.logPurchase('reactProductIdentifier', '1.2', 'USD', 2, {
-      stringKey: 'stringValue',
-      intKey: 42,
-      floatKey: 1.23,
-      boolKey: true,
-      dateKey: testDate,
-      dictKey: {dictKey1: 'dictVal1'},
-    });
-    ReactAppboy.logPurchase(
-      'reactProductIdentifier' + 'NoProps',
-      '1.2',
-      'USD',
-      2,
-    );
+    ReactAppboy.logPurchase('reactProductIdentifier', '1.2', 'USD', 2, {'stringKey': 'stringValue', 'intKey': 42, 'floatKey': 1.23, 'boolKey': true, 'dateKey': testDate, 'dictKey':{'dictKey1': 'dictVal1'}});
+    ReactAppboy.logPurchase('reactProductIdentifier' + 'NoProps', '1.2', 'USD', 2);
     this._showToast('Purchase logged');
   }
   _logCustomAttributePress(event) {
@@ -491,15 +435,9 @@ class AppboyProject extends Component {
       }
     });
     ReactAppboy.setPhoneNumber('9085555555');
-    ReactAppboy.setAvatarImageUrl(
-      'https://raw.githubusercontent.com/Appboy/appboy-react-sdk/master/braze-logo.png',
-    );
-    ReactAppboy.setEmailNotificationSubscriptionType(
-      ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED,
-    );
-    ReactAppboy.setPushNotificationSubscriptionType(
-      ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED,
-    );
+    ReactAppboy.setAvatarImageUrl('https://raw.githubusercontent.com/Appboy/appboy-react-sdk/master/braze-logo.png');
+    ReactAppboy.setEmailNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED);
+    ReactAppboy.setPushNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED);
     ReactAppboy.addAlias('arrayattr', 'alias-label-1');
     this._showToast('User properties set');
   }
@@ -527,16 +465,8 @@ class AppboyProject extends Component {
     this._showToast('Attribute incremented');
   }
   _setTwitterData(event) {
-    ReactAppboy.setTwitterData(
-      6253282,
-      'billmag',
-      'Bill',
-      'Adventurer',
-      700,
-      200,
-      1000,
-      'https://si0.twimg.com/profile_images/2685532587/fa47382ad67a0135acc62d4c6b49dbdc_bigger.jpeg',
-    );
+    ReactAppboy.setTwitterData(6253282, 'billmag', 'Bill', 'Adventurer', 700, 200, 1000,
+        'https://si0.twimg.com/profile_images/2685532587/fa47382ad67a0135acc62d4c6b49dbdc_bigger.jpeg');
     this._showToast('Twitter data set');
   }
   _setFacebookData(event) {
@@ -545,30 +475,29 @@ class AppboyProject extends Component {
       first_name: 'Bill',
       last_name: 'Mag',
       location: {
-        name: 'new york',
+        name: 'new york'
       },
       age_range: {
-        min: 21,
-        max: 31,
+        min: 21, max: 31
       },
       email: 'bill@m.ag',
       bio: 'adventurer',
       gender: 'male',
-      birthday: '01/01/2016',
+      birthday: '01/01/2016'
     };
     // May also be a list of strings, e.g. below:
     // var likes = ["Messiaen", "Durufle", "Buxtehude"];
     var likes = [
       {
-        name: 'Hot Rabbit',
-        id: '199600656843963',
-        created_time: '2016-09-25T17:05:01+0000',
+        'name': 'Hot Rabbit',
+        'id': '199600656843963',
+        'created_time': '2016-09-25T17:05:01+0000'
       },
       {
-        name: 'This Bridge Called Our Health',
-        id: '543928779075283',
-        created_time: '2016-09-24T20:43:01+0000',
-      },
+        'name': 'This Bridge Called Our Health',
+        'id': '543928779075283',
+        'created_time': '2016-09-24T20:43:01+0000'
+      }
     ];
     ReactAppboy.setFacebookData(profile, 500, likes);
     this._showToast('Facebook data set');
@@ -585,29 +514,35 @@ class AppboyProject extends Component {
   }
 
   _wipeData(event) {
-    Alert.alert('Wipe Data', 'Are you sure?', [
-      {text: 'Cancel', style: 'cancel'},
-      {
-        text: 'OK',
-        onPress: () => {
-          ReactAppboy.wipeData();
-          this._showToast('Data wiped');
-        },
-      },
-    ]);
+    Alert.alert(
+      'Wipe Data',
+      'Are you sure?',
+      [
+        {text: 'Cancel', style: 'cancel'},
+        {
+          text: 'OK', onPress: () => {
+            ReactAppboy.wipeData();
+            this._showToast('Data wiped');
+          }
+        }
+      ]
+    );
   }
 
   _disableSDK(event) {
-    Alert.alert('Disable SDK', 'Are you sure?', [
-      {text: 'Cancel', style: 'cancel'},
-      {
-        text: 'OK',
-        onPress: () => {
-          ReactAppboy.disableSDK();
-          this._showToast('SDK disabled');
-        },
-      },
-    ]);
+    Alert.alert(
+      'Disable SDK',
+      'Are you sure?',
+      [
+        {text: 'Cancel', style: 'cancel'},
+        {
+          text: 'OK', onPress: () => {
+            ReactAppboy.disableSDK();
+            this._showToast('SDK disabled');
+          }
+        }
+      ]
+    );
   }
 
   _enableSDK(event) {
@@ -630,7 +565,7 @@ class AppboyProject extends Component {
   }
 
   _setLocationCustomAttribute(event) {
-    ReactAppboy.setLocationCustomAttribute('work', 40.7128, 74.006);
+    ReactAppboy.setLocationCustomAttribute("work", 40.7128, 74.0060);
     this._showToast('Location Set');
   }
 
@@ -645,10 +580,10 @@ class AppboyProject extends Component {
   }
 
   _setAttributionData(event) {
-    var network = 'fakeblock';
-    var campaign = 'everyone';
-    var adGroup = 'adgroup1';
-    var creative = 'bigBanner';
+    var network = "fakeblock";
+    var campaign = "everyone";
+    var adGroup = "adgroup1";
+    var creative = "bigBanner";
     ReactAppboy.setAttributionData(network, campaign, adGroup, creative);
     this._showToast('Attribution Data Set');
   }
@@ -664,25 +599,23 @@ class AppboyProject extends Component {
   }
 
   _getContentCards(event) {
-    ReactAppboy.getContentCards()
-      .then(function(result) {
-        if (result === undefined || result.length == 0) {
-          console.log('No cached Content Cards Found.');
-        } else {
-          console.log(result.length + ' cached Content Cards Found.');
-          for (var i = 0; i < result.length; i++) {
-            var cardId = result[i].id;
-            console.log('Got content card: ' + JSON.stringify(result[i]));
-            ReactAppboy.logContentCardClicked(cardId);
-            ReactAppboy.logContentCardImpression(cardId);
-            // ReactAppboy.logContentCardDismissed(cardId);
-          }
-          ReactAppboy.logContentCardsDisplayed(cardId);
+    ReactAppboy.getContentCards().then(function(result) {
+      if (result === undefined || result.length == 0) {
+        console.log('No cached Content Cards Found.');
+      } else {
+        console.log(result.length + ' cached Content Cards Found.');
+        for (var i = 0; i < result.length; i++) {
+          var cardId = result[i].id;
+          console.log('Got content card: ' + JSON.stringify(result[i]));
+          ReactAppboy.logContentCardClicked(cardId);
+          ReactAppboy.logContentCardImpression(cardId);
+          // ReactAppboy.logContentCardDismissed(cardId);
         }
-      })
-      .catch(function() {
-        console.log('Content Cards Promise Rejected');
-      });
+        ReactAppboy.logContentCardsDisplayed(cardId);
+      }
+    }).catch(function () {
+      console.log("Content Cards Promise Rejected");
+    });
   }
 }
 
@@ -692,41 +625,41 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#F5FCFF',
     paddingTop: 100,
-    paddingBottom: 100,
+    paddingBottom: 100
   },
   textInput: {
     height: 40,
     width: 150,
     borderColor: 'gray',
-    borderWidth: 0.5,
+    borderWidth: .5,
     paddingLeft: 5,
     marginLeft: 5,
-    fontSize: 14,
+    fontSize: 14
   },
   row: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'center'
   },
   picker: {
-    width: 200,
+    width: 200
   },
   toastView: {
-    display: 'flex',
+    display: "flex",
     height: 80,
-    backgroundColor: 'green',
-    position: 'absolute',
+    backgroundColor: "green",
+    position: "absolute",
     left: 0,
     top: 0,
     right: 0,
-    alignItems: 'center',
-    flexDirection: 'row',
+    alignItems: "center",
+    flexDirection: 'row'
   },
   toastText: {
     marginLeft: 10,
     color: 'white',
     fontSize: 15,
-    fontWeight: 'bold',
-  },
+    fontWeight: 'bold'
+  }
 });
 
 export default AppboyProject;

--- a/AppboyProject/AppboyProject.js
+++ b/AppboyProject/AppboyProject.js
@@ -1,5 +1,5 @@
 'use strict';
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import {
   StyleSheet,
   Text,
@@ -11,7 +11,7 @@ import {
   Alert,
   TextInput,
   Platform,
-  DeviceEventEmitter
+  DeviceEventEmitter,
 } from 'react-native';
 
 const ReactAppboy = require('react-native-appboy-sdk');
@@ -20,40 +20,59 @@ class AppboyProject extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      userIdText : '',
+      userIdText: '',
       signatureText: '',
-      customEventText : '',
-      subscriptionState : 's',
-      gender : 'm',
+      customEventText: '',
+      subscriptionState: 's',
+      gender: 'm',
       message: 'Success',
-      toastVisible: 0
+      toastVisible: 0,
     };
     this._getInstallTrackingId = this._getInstallTrackingId.bind(this);
     this._updateCardCount = this._updateCardCount.bind(this);
     this._changeUserPress = this._changeUserPress.bind(this);
     this._setSignaturePress = this._setSignaturePress.bind(this);
     this._logCustomEventPress = this._logCustomEventPress.bind(this);
-    this._setSubscriptionStatePress = this._setSubscriptionStatePress.bind(this);
+    this._setSubscriptionStatePress = this._setSubscriptionStatePress.bind(
+      this,
+    );
     this._logPurchasePress = this._logPurchasePress.bind(this);
     this._setLanguagePress = this._setLanguagePress.bind(this);
     this._logCustomAttributePress = this._logCustomAttributePress.bind(this);
     this._logUserPropertiesPress = this._logUserPropertiesPress.bind(this);
-    this._unsetCustomUserAttributePress = this._unsetCustomUserAttributePress.bind(this);
-    this._addToCustomAttributeArrayPress = this._addToCustomAttributeArrayPress.bind(this);
-    this._removeFromCustomAttributeArrayPress = this._removeFromCustomAttributeArrayPress.bind(this);
-    this._incrementCustomAttributePress = this._incrementCustomAttributePress.bind(this);
+    this._unsetCustomUserAttributePress = this._unsetCustomUserAttributePress.bind(
+      this,
+    );
+    this._addToCustomAttributeArrayPress = this._addToCustomAttributeArrayPress.bind(
+      this,
+    );
+    this._removeFromCustomAttributeArrayPress = this._removeFromCustomAttributeArrayPress.bind(
+      this,
+    );
+    this._incrementCustomAttributePress = this._incrementCustomAttributePress.bind(
+      this,
+    );
     this._setTwitterData = this._setTwitterData.bind(this);
     this._setFacebookData = this._setFacebookData.bind(this);
     this._requestFeedRefresh = this._requestFeedRefresh.bind(this);
-    this._requestImmediateDataFlush = this._requestImmediateDataFlush.bind(this);
+    this._requestImmediateDataFlush = this._requestImmediateDataFlush.bind(
+      this,
+    );
     this._wipeData = this._wipeData.bind(this);
     this._disableSDK = this._disableSDK.bind(this);
     this._enableSDK = this._enableSDK.bind(this);
-    this._requestLocationInitialization = this._requestLocationInitialization.bind(this);
+    this._requestPermission = this._requestPermission.bind(this);
+    this._requestLocationInitialization = this._requestLocationInitialization.bind(
+      this,
+    );
     this._requestGeofences = this._requestGeofences.bind(this);
-    this._setLocationCustomAttribute = this._setLocationCustomAttribute.bind(this);
+    this._setLocationCustomAttribute = this._setLocationCustomAttribute.bind(
+      this,
+    );
     this._setGenderPress = this._setGenderPress.bind(this);
-    this._requestContentCardsRefresh = this._requestContentCardsRefresh.bind(this);
+    this._requestContentCardsRefresh = this._requestContentCardsRefresh.bind(
+      this,
+    );
     this._hideCurrentInAppMessage = this._hideCurrentInAppMessage.bind(this);
     this._setAttributionData = this._setAttributionData.bind(this);
     this._getContentCards = this._getContentCards.bind(this);
@@ -67,13 +86,15 @@ class AppboyProject extends Component {
 
     // No `url` event is triggered on application start, so this handles
     // the case where a deep link launches the application
-    Linking.getInitialURL().then((url) => {
-      if (url) {
-        console.log('Linking.getInitialURL is ' + url);
-        this._showToast('Linking.getInitialURL is ' + url);
-        this._handleOpenUrl({url});
-      }
-    }).catch(err => console.error('Error getting initial URL', err));
+    Linking.getInitialURL()
+      .then(url => {
+        if (url) {
+          console.log('Linking.getInitialURL is ' + url);
+          this._showToast('Linking.getInitialURL is ' + url);
+          this._handleOpenUrl({url});
+        }
+      })
+      .catch(err => console.error('Error getting initial URL', err));
 
     // Handles deep links when an iOS app is launched from hard close via push click.
     // Note that this isn't handled by Linking.getInitialURL(), as the app is
@@ -88,22 +109,37 @@ class AppboyProject extends Component {
       }
     });
 
-    ReactAppboy.addListener(ReactAppboy.Events.CONTENT_CARDS_UPDATED, function() {
-      console.log('Content Cards Updated.');
-    });
+    ReactAppboy.addListener(
+      ReactAppboy.Events.CONTENT_CARDS_UPDATED,
+      function() {
+        console.log('Content Cards Updated.');
+      },
+    );
 
-    ReactAppboy.addListener(ReactAppboy.Events.SDK_AUTHENTICATION_ERROR, function(data) {
-      console.log(`SDK Authentication for ${data.user_id} failed with error code ${data.error_code}.`);
-    });
+    ReactAppboy.addListener(
+      ReactAppboy.Events.SDK_AUTHENTICATION_ERROR,
+      function(data) {
+        console.log(
+          `SDK Authentication for ${data.user_id} failed with error code ${
+            data.error_code
+          }.`,
+        );
+      },
+    );
 
-    this._listener = DeviceEventEmitter.addListener("inAppMessageReceived", function(event) {
-      let inAppMessage = new ReactAppboy.BrazeInAppMessage(event.inAppMessage);
-      ReactAppboy.logInAppMessageClicked(inAppMessage);
-      ReactAppboy.logInAppMessageImpression(inAppMessage);
-      ReactAppboy.logInAppMessageButtonClicked(inAppMessage, 0);
-      that._showToast('inAppMessage received in the React layer');
-      console.log(inAppMessage);
-    })
+    this._listener = DeviceEventEmitter.addListener(
+      'inAppMessageReceived',
+      function(event) {
+        let inAppMessage = new ReactAppboy.BrazeInAppMessage(
+          event.inAppMessage,
+        );
+        ReactAppboy.logInAppMessageClicked(inAppMessage);
+        ReactAppboy.logInAppMessageImpression(inAppMessage);
+        ReactAppboy.logInAppMessageButtonClicked(inAppMessage, 0);
+        that._showToast('inAppMessage received in the React layer');
+        console.log(inAppMessage);
+      },
+    );
   }
 
   componentWillUnmount() {
@@ -113,30 +149,37 @@ class AppboyProject extends Component {
 
   _handleOpenUrl(event) {
     console.log('handleOpenUrl called on url ' + event.url);
-    Alert.alert(
-      'Deep Link',
-      event.url,
-      [
-        {text: 'OK', onPress: () => console.log('OK Pressed')}
-      ]
-    );
+    Alert.alert('Deep Link', event.url, [
+      {text: 'OK', onPress: () => console.log('OK Pressed')},
+    ]);
   }
 
   _updateCardCount() {
-    ReactAppboy.getUnreadCardCountForCategories(ReactAppboy.CardCategory.ALL, (err, res) => {
-      if (err) {
-        console.log('getUnreadCardCountForCategories returned error ' + err);
-      } else if (res != null) {
-        this.setState({unreadCardCount: res});
-      }
-    });
-    ReactAppboy.getCardCountForCategories(ReactAppboy.CardCategory.ALL, (err, res) => {
-      if (err) {
-        console.log('getCardCountForCategories returned error ' + err);
-      } else if (res != null) {
-        this.setState({cardCount: res});
-      }
-    });
+    ReactAppboy.getUnreadCardCountForCategories(
+      ReactAppboy.CardCategory.ALL,
+      (err, res) => {
+        if (err) {
+          console.log('getUnreadCardCountForCategories returned error ' + err);
+        } else if (res != null) {
+          this.setState({unreadCardCount: res});
+        }
+      },
+    );
+    ReactAppboy.getCardCountForCategories(
+      ReactAppboy.CardCategory.ALL,
+      (err, res) => {
+        if (err) {
+          console.log('getCardCountForCategories returned error ' + err);
+        } else if (res != null) {
+          this.setState({cardCount: res});
+        }
+      },
+    );
+  }
+
+  async _requestPermission() {
+    const result = await ReactAppboy.requestPermission();
+    console.log('Permission request result ', {result});
   }
 
   render() {
@@ -144,67 +187,57 @@ class AppboyProject extends Component {
       <ScrollView
         contentContainerStyle={styles.container}
         stickyHeaderIndices={[0]}>
-        <View
-          style={[styles.toastView, {opacity: this.state.toastVisible}]}>
-          <Text
-            style={styles.toastText}>
-            {this.state.message}
-          </Text>
+        <View style={[styles.toastView, {opacity: this.state.toastVisible}]}>
+          <Text style={styles.toastText}>{this.state.message}</Text>
         </View>
         <View style={styles.row}>
           <TextInput
             style={styles.textInput}
-            onChangeText={(userIdText) => this.setState({userIdText})}
+            onChangeText={userIdText => this.setState({userIdText})}
             value={this.state.userIdText}
-            />
-          <TouchableHighlight
-            onPress={this._changeUserPress}>
+          />
+          <TouchableHighlight onPress={this._changeUserPress}>
             <Text>Set User ID</Text>
           </TouchableHighlight>
         </View>
         <View style={styles.row}>
           <TextInput
             style={styles.textInput}
-            onChangeText={(signatureText) => this.setState({signatureText})}
+            onChangeText={signatureText => this.setState({signatureText})}
             value={this.state.signatureText}
-            />
-          <TouchableHighlight
-            onPress={this._setSignaturePress}>
+          />
+          <TouchableHighlight onPress={this._setSignaturePress}>
             <Text>Set Signature</Text>
           </TouchableHighlight>
         </View>
         <View style={styles.row}>
           <TextInput
             style={styles.textInput}
-            onChangeText={(customEventText) => this.setState({customEventText})}/>
-          <TouchableHighlight
-            onPress={this._logCustomEventPress}>
+            onChangeText={customEventText => this.setState({customEventText})}
+          />
+          <TouchableHighlight onPress={this._logCustomEventPress}>
             <Text>Log Custom Event</Text>
           </TouchableHighlight>
         </View>
         <View style={styles.row}>
           <TextInput
             style={styles.textInput}
-            onChangeText={(languageText) => this.setState({languageText})}/>
-          <TouchableHighlight
-            onPress={this._setLanguagePress}>
+            onChangeText={languageText => this.setState({languageText})}
+          />
+          <TouchableHighlight onPress={this._setLanguagePress}>
             <Text>Set Language</Text>
           </TouchableHighlight>
         </View>
-        <TouchableHighlight
-          onPress={this._logPurchasePress}>
+        <TouchableHighlight onPress={this._logPurchasePress}>
           <Text>Log Purchase</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._logCustomAttributePress}>
+        <TouchableHighlight onPress={this._logCustomAttributePress}>
           <Text>Set Custom User Attributes</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._logUserPropertiesPress}>
+        <TouchableHighlight onPress={this._logUserPropertiesPress}>
           <Text>Set User Properties</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._hideCurrentInAppMessage}>
+        <TouchableHighlight onPress={this._hideCurrentInAppMessage}>
           <Text>Dismiss In App Message</Text>
         </TouchableHighlight>
         <View style={styles.row}>
@@ -212,13 +245,12 @@ class AppboyProject extends Component {
             style={styles.picker}
             itemStyle={{fontSize: 16}}
             selectedValue={this.state.subscriptionState}
-            onValueChange={(value) => this.setState({subscriptionState: value})}>
-            <Picker.Item label='Subscribed' value='s' />
-            <Picker.Item label='Unsubscribed' value='u' />
-            <Picker.Item label='Opted-in' value='o' />
+            onValueChange={value => this.setState({subscriptionState: value})}>
+            <Picker.Item label="Subscribed" value="s" />
+            <Picker.Item label="Unsubscribed" value="u" />
+            <Picker.Item label="Opted-in" value="o" />
           </Picker>
-          <TouchableHighlight
-            onPress={this._setSubscriptionStatePress}>
+          <TouchableHighlight onPress={this._setSubscriptionStatePress}>
             <Text>Set Subscription State</Text>
           </TouchableHighlight>
         </View>
@@ -227,116 +259,103 @@ class AppboyProject extends Component {
             style={styles.picker}
             itemStyle={{fontSize: 16}}
             selectedValue={this.state.gender}
-            onValueChange={(value) => this.setState({gender: value})}>
-            <Picker.Item label='Female' value='f' />
-            <Picker.Item label='Male' value='m' />
-            <Picker.Item label='Not Applicable' value='n' />
-            <Picker.Item label='Other' value='o' />
-            <Picker.Item label='Prefer Not to Say' value='p' />
-            <Picker.Item label='Unknown' value='u' />
+            onValueChange={value => this.setState({gender: value})}>
+            <Picker.Item label="Female" value="f" />
+            <Picker.Item label="Male" value="m" />
+            <Picker.Item label="Not Applicable" value="n" />
+            <Picker.Item label="Other" value="o" />
+            <Picker.Item label="Prefer Not to Say" value="p" />
+            <Picker.Item label="Unknown" value="u" />
           </Picker>
-          <TouchableHighlight
-            onPress={this._setGenderPress}>
+          <TouchableHighlight onPress={this._setGenderPress}>
             <Text>Set Gender</Text>
           </TouchableHighlight>
         </View>
-        <TouchableHighlight
-          onPress={this._unsetCustomUserAttributePress}>
+        <TouchableHighlight onPress={this._unsetCustomUserAttributePress}>
           <Text>Unset Custom User Attributes</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._addToCustomAttributeArrayPress}>
+        <TouchableHighlight onPress={this._addToCustomAttributeArrayPress}>
           <Text>Add to Custom Attribute Array</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._removeFromCustomAttributeArrayPress}>
+        <TouchableHighlight onPress={this._removeFromCustomAttributeArrayPress}>
           <Text>Remove From Custom Attribute Array</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._incrementCustomAttributePress}>
+        <TouchableHighlight onPress={this._incrementCustomAttributePress}>
           <Text>Increment Custom Attribute Array</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._setTwitterData}>
+        <TouchableHighlight onPress={this._setTwitterData}>
           <Text>Set Twitter Data</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._setFacebookData}>
+        <TouchableHighlight onPress={this._setFacebookData}>
           <Text>Set Facebook Data</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._launchNewsFeedPress}>
+        <TouchableHighlight onPress={this._launchNewsFeedPress}>
           <Text>Launch News Feed</Text>
         </TouchableHighlight>
         <TouchableHighlight onPress={this._updateCardCount}>
-          <Text>Unread Cards (Click to Refresh): {this.state.unreadCardCount} / {this.state.cardCount}</Text>
+          <Text>
+            Unread Cards (Click to Refresh): {this.state.unreadCardCount} /{' '}
+            {this.state.cardCount}
+          </Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._requestFeedRefresh}>
+        <TouchableHighlight onPress={this._requestFeedRefresh}>
           <Text>Request Feed Refresh</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._launchContentCardsPress}>
+        <TouchableHighlight onPress={this._launchContentCardsPress}>
           <Text>Launch Content Cards</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._requestContentCardsRefresh}>
+        <TouchableHighlight onPress={this._requestContentCardsRefresh}>
           <Text>Request Content Cards Refresh</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._requestImmediateDataFlush}>
+        <TouchableHighlight onPress={this._requestImmediateDataFlush}>
           <Text>Request Immediate Data Flush</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._wipeData}>
+        <TouchableHighlight onPress={this._wipeData}>
           <Text>Wipe Data</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._disableSDK}>
+        <TouchableHighlight onPress={this._disableSDK}>
           <Text>Disable SDK</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._enableSDK}>
+        <TouchableHighlight onPress={this._enableSDK}>
           <Text>Enable SDK</Text>
         </TouchableHighlight>
-        { Platform.OS === 'android' ?
-        <TouchableHighlight
-          onPress={this._requestLocationInitialization}>
-          <Text>Request Location Initialization</Text>
-        </TouchableHighlight>
-        : false }
-        <TouchableHighlight
-          onPress={this._requestGeofences}>
+        {Platform.OS === 'android' ? (
+          <TouchableHighlight onPress={this._requestLocationInitialization}>
+            <Text>Request Location Initialization</Text>
+          </TouchableHighlight>
+        ) : (
+          false
+        )}
+        <TouchableHighlight onPress={this._requestGeofences}>
           <Text>Request Geofences</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._setLocationCustomAttribute}>
+        <TouchableHighlight onPress={this._setLocationCustomAttribute}>
           <Text>Set Custom Location Attribute</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._setAttributionData}>
+        <TouchableHighlight onPress={this._setAttributionData}>
           <Text>Set Attribution Data</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._getInstallTrackingId}>
+        <TouchableHighlight onPress={this._getInstallTrackingId}>
           <Text>Get Install Tracking ID</Text>
         </TouchableHighlight>
-        <TouchableHighlight
-          onPress={this._getContentCards}>
+        <TouchableHighlight onPress={this._getContentCards}>
           <Text>Request Cached Content Cards</Text>
         </TouchableHighlight>
-        </ScrollView>
+        <TouchableHighlight onPress={this._requestPermission}>
+          <Text>Request permission ios</Text>
+        </TouchableHighlight>
+      </ScrollView>
     );
   }
   _showToast(message) {
-    this.setState({ message: message });
+    this.setState({message: message});
     this.setState({toastVisible: 1}, this._hideToast);
   }
   _hideToast() {
     setTimeout(() => {
-      this.setState({ message: 'Success' });
+      this.setState({message: 'Success'});
       this.setState({toastVisible: 0});
-    }, 1000)
+    }, 1000);
   }
   _changeUserPress(event) {
     ReactAppboy.changeUser(this.state.userIdText);
@@ -348,9 +367,29 @@ class AppboyProject extends Component {
   }
   _logCustomEventPress(event) {
     var testDate = new Date();
-    ReactAppboy.logCustomEvent(this.state.customEventText, {'stringKey': 'stringValue', 'intKey': 42, 'floatKey': 1.23, 'boolKey': true, 'dateKey': testDate});
+    ReactAppboy.logCustomEvent(this.state.customEventText, {
+      stringKey: 'stringValue',
+      intKey: 42,
+      floatKey: 1.23,
+      boolKey: true,
+      dateKey: testDate,
+    });
     ReactAppboy.logCustomEvent(this.state.customEventText + 'NoProps');
-    ReactAppboy.logCustomEvent(this.state.customEventText, {'arrayKey': ['arrayVal1', 'arrayVal2', testDate, [testDate, 'nestedArrayval'], {'dictInArrayKey': testDate}], 'dictKey': {'dictKey1': 'dictVal1', 'dictKey2': testDate, 'dictKey3': {'nestedDictKey1': testDate}, 'dictKey4': ['nestedArrayVal1', 'nestedArrayVal2']}});
+    ReactAppboy.logCustomEvent(this.state.customEventText, {
+      arrayKey: [
+        'arrayVal1',
+        'arrayVal2',
+        testDate,
+        [testDate, 'nestedArrayval'],
+        {dictInArrayKey: testDate},
+      ],
+      dictKey: {
+        dictKey1: 'dictVal1',
+        dictKey2: testDate,
+        dictKey3: {nestedDictKey1: testDate},
+        dictKey4: ['nestedArrayVal1', 'nestedArrayVal2'],
+      },
+    });
     this._showToast('Event logged: ' + this.state.customEventText);
   }
   _setLanguagePress(event) {
@@ -358,47 +397,74 @@ class AppboyProject extends Component {
     this._showToast('Language changed to: ' + this.state.languageText);
   }
   _setSubscriptionStatePress(event) {
-    console.log('Received request to change subscription state for email and push to ' + this.state.subscriptionState);
+    console.log(
+      'Received request to change subscription state for email and push to ' +
+        this.state.subscriptionState,
+    );
     if (this.state.subscriptionState == 'o') {
-      ReactAppboy.setEmailNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.OPTED_IN);
-      ReactAppboy.setPushNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.OPTED_IN);
+      ReactAppboy.setEmailNotificationSubscriptionType(
+        ReactAppboy.NotificationSubscriptionTypes.OPTED_IN,
+      );
+      ReactAppboy.setPushNotificationSubscriptionType(
+        ReactAppboy.NotificationSubscriptionTypes.OPTED_IN,
+      );
       this._showToast('User opted in to Email & Push');
     } else if (this.state.subscriptionState == 'u') {
-      ReactAppboy.setEmailNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED);
-      ReactAppboy.setPushNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED);
+      ReactAppboy.setEmailNotificationSubscriptionType(
+        ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED,
+      );
+      ReactAppboy.setPushNotificationSubscriptionType(
+        ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED,
+      );
       this._showToast('User unsubscribed from Email & Push');
     } else if (this.state.subscriptionState == 's') {
-      ReactAppboy.setEmailNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED);
-      ReactAppboy.setPushNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED);
+      ReactAppboy.setEmailNotificationSubscriptionType(
+        ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED,
+      );
+      ReactAppboy.setPushNotificationSubscriptionType(
+        ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED,
+      );
       this._showToast('User subscribed to Email & Push');
     }
   }
   _setGenderPress(event) {
     console.log('Received request to change gender to ' + this.state.gender);
     if (this.state.gender == 'f') {
-      ReactAppboy.setGender(ReactAppboy.Genders.FEMALE)
+      ReactAppboy.setGender(ReactAppboy.Genders.FEMALE);
       this._showToast('User gender set to "female"');
     } else if (this.state.gender == 'm') {
-      ReactAppboy.setGender(ReactAppboy.Genders.MALE)
+      ReactAppboy.setGender(ReactAppboy.Genders.MALE);
       this._showToast('User gender set to "male"');
-    }  else if (this.state.gender == 'n') {
-      ReactAppboy.setGender(ReactAppboy.Genders.NOT_APPLICABLE)
+    } else if (this.state.gender == 'n') {
+      ReactAppboy.setGender(ReactAppboy.Genders.NOT_APPLICABLE);
       this._showToast('User gender set to "not applicable"');
     } else if (this.state.gender == 'o') {
-      ReactAppboy.setGender(ReactAppboy.Genders.OTHER)
+      ReactAppboy.setGender(ReactAppboy.Genders.OTHER);
       this._showToast('User gender set to "other"');
     } else if (this.state.gender == 'p') {
-      ReactAppboy.setGender(ReactAppboy.Genders.PREFER_NOT_TO_SAY)
+      ReactAppboy.setGender(ReactAppboy.Genders.PREFER_NOT_TO_SAY);
       this._showToast('User gender set to "prefer not to say"');
     } else if (this.state.gender == 'u') {
-      ReactAppboy.setGender(ReactAppboy.Genders.UNKNOWN)
+      ReactAppboy.setGender(ReactAppboy.Genders.UNKNOWN);
       this._showToast('User gender set to "unknown"');
     }
   }
   _logPurchasePress(event) {
     var testDate = new Date();
-    ReactAppboy.logPurchase('reactProductIdentifier', '1.2', 'USD', 2, {'stringKey': 'stringValue', 'intKey': 42, 'floatKey': 1.23, 'boolKey': true, 'dateKey': testDate, 'dictKey':{'dictKey1': 'dictVal1'}});
-    ReactAppboy.logPurchase('reactProductIdentifier' + 'NoProps', '1.2', 'USD', 2);
+    ReactAppboy.logPurchase('reactProductIdentifier', '1.2', 'USD', 2, {
+      stringKey: 'stringValue',
+      intKey: 42,
+      floatKey: 1.23,
+      boolKey: true,
+      dateKey: testDate,
+      dictKey: {dictKey1: 'dictVal1'},
+    });
+    ReactAppboy.logPurchase(
+      'reactProductIdentifier' + 'NoProps',
+      '1.2',
+      'USD',
+      2,
+    );
     this._showToast('Purchase logged');
   }
   _logCustomAttributePress(event) {
@@ -425,9 +491,15 @@ class AppboyProject extends Component {
       }
     });
     ReactAppboy.setPhoneNumber('9085555555');
-    ReactAppboy.setAvatarImageUrl('https://raw.githubusercontent.com/Appboy/appboy-react-sdk/master/braze-logo.png');
-    ReactAppboy.setEmailNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED);
-    ReactAppboy.setPushNotificationSubscriptionType(ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED);
+    ReactAppboy.setAvatarImageUrl(
+      'https://raw.githubusercontent.com/Appboy/appboy-react-sdk/master/braze-logo.png',
+    );
+    ReactAppboy.setEmailNotificationSubscriptionType(
+      ReactAppboy.NotificationSubscriptionTypes.UNSUBSCRIBED,
+    );
+    ReactAppboy.setPushNotificationSubscriptionType(
+      ReactAppboy.NotificationSubscriptionTypes.SUBSCRIBED,
+    );
     ReactAppboy.addAlias('arrayattr', 'alias-label-1');
     this._showToast('User properties set');
   }
@@ -455,8 +527,16 @@ class AppboyProject extends Component {
     this._showToast('Attribute incremented');
   }
   _setTwitterData(event) {
-    ReactAppboy.setTwitterData(6253282, 'billmag', 'Bill', 'Adventurer', 700, 200, 1000,
-        'https://si0.twimg.com/profile_images/2685532587/fa47382ad67a0135acc62d4c6b49dbdc_bigger.jpeg');
+    ReactAppboy.setTwitterData(
+      6253282,
+      'billmag',
+      'Bill',
+      'Adventurer',
+      700,
+      200,
+      1000,
+      'https://si0.twimg.com/profile_images/2685532587/fa47382ad67a0135acc62d4c6b49dbdc_bigger.jpeg',
+    );
     this._showToast('Twitter data set');
   }
   _setFacebookData(event) {
@@ -465,29 +545,30 @@ class AppboyProject extends Component {
       first_name: 'Bill',
       last_name: 'Mag',
       location: {
-        name: 'new york'
+        name: 'new york',
       },
       age_range: {
-        min: 21, max: 31
+        min: 21,
+        max: 31,
       },
       email: 'bill@m.ag',
       bio: 'adventurer',
       gender: 'male',
-      birthday: '01/01/2016'
+      birthday: '01/01/2016',
     };
     // May also be a list of strings, e.g. below:
     // var likes = ["Messiaen", "Durufle", "Buxtehude"];
     var likes = [
       {
-        'name': 'Hot Rabbit',
-        'id': '199600656843963',
-        'created_time': '2016-09-25T17:05:01+0000'
+        name: 'Hot Rabbit',
+        id: '199600656843963',
+        created_time: '2016-09-25T17:05:01+0000',
       },
       {
-        'name': 'This Bridge Called Our Health',
-        'id': '543928779075283',
-        'created_time': '2016-09-24T20:43:01+0000'
-      }
+        name: 'This Bridge Called Our Health',
+        id: '543928779075283',
+        created_time: '2016-09-24T20:43:01+0000',
+      },
     ];
     ReactAppboy.setFacebookData(profile, 500, likes);
     this._showToast('Facebook data set');
@@ -504,35 +585,29 @@ class AppboyProject extends Component {
   }
 
   _wipeData(event) {
-    Alert.alert(
-      'Wipe Data',
-      'Are you sure?',
-      [
-        {text: 'Cancel', style: 'cancel'},
-        {
-          text: 'OK', onPress: () => {
-            ReactAppboy.wipeData();
-            this._showToast('Data wiped');
-          }
-        }
-      ]
-    );
+    Alert.alert('Wipe Data', 'Are you sure?', [
+      {text: 'Cancel', style: 'cancel'},
+      {
+        text: 'OK',
+        onPress: () => {
+          ReactAppboy.wipeData();
+          this._showToast('Data wiped');
+        },
+      },
+    ]);
   }
 
   _disableSDK(event) {
-    Alert.alert(
-      'Disable SDK',
-      'Are you sure?',
-      [
-        {text: 'Cancel', style: 'cancel'},
-        {
-          text: 'OK', onPress: () => {
-            ReactAppboy.disableSDK();
-            this._showToast('SDK disabled');
-          }
-        }
-      ]
-    );
+    Alert.alert('Disable SDK', 'Are you sure?', [
+      {text: 'Cancel', style: 'cancel'},
+      {
+        text: 'OK',
+        onPress: () => {
+          ReactAppboy.disableSDK();
+          this._showToast('SDK disabled');
+        },
+      },
+    ]);
   }
 
   _enableSDK(event) {
@@ -555,7 +630,7 @@ class AppboyProject extends Component {
   }
 
   _setLocationCustomAttribute(event) {
-    ReactAppboy.setLocationCustomAttribute("work", 40.7128, 74.0060);
+    ReactAppboy.setLocationCustomAttribute('work', 40.7128, 74.006);
     this._showToast('Location Set');
   }
 
@@ -570,10 +645,10 @@ class AppboyProject extends Component {
   }
 
   _setAttributionData(event) {
-    var network = "fakeblock";
-    var campaign = "everyone";
-    var adGroup = "adgroup1";
-    var creative = "bigBanner";
+    var network = 'fakeblock';
+    var campaign = 'everyone';
+    var adGroup = 'adgroup1';
+    var creative = 'bigBanner';
     ReactAppboy.setAttributionData(network, campaign, adGroup, creative);
     this._showToast('Attribution Data Set');
   }
@@ -589,23 +664,25 @@ class AppboyProject extends Component {
   }
 
   _getContentCards(event) {
-    ReactAppboy.getContentCards().then(function(result) {
-      if (result === undefined || result.length == 0) {
-        console.log('No cached Content Cards Found.');
-      } else {
-        console.log(result.length + ' cached Content Cards Found.');
-        for (var i = 0; i < result.length; i++) {
-          var cardId = result[i].id;
-          console.log('Got content card: ' + JSON.stringify(result[i]));
-          ReactAppboy.logContentCardClicked(cardId);
-          ReactAppboy.logContentCardImpression(cardId);
-          // ReactAppboy.logContentCardDismissed(cardId);
+    ReactAppboy.getContentCards()
+      .then(function(result) {
+        if (result === undefined || result.length == 0) {
+          console.log('No cached Content Cards Found.');
+        } else {
+          console.log(result.length + ' cached Content Cards Found.');
+          for (var i = 0; i < result.length; i++) {
+            var cardId = result[i].id;
+            console.log('Got content card: ' + JSON.stringify(result[i]));
+            ReactAppboy.logContentCardClicked(cardId);
+            ReactAppboy.logContentCardImpression(cardId);
+            // ReactAppboy.logContentCardDismissed(cardId);
+          }
+          ReactAppboy.logContentCardsDisplayed(cardId);
         }
-        ReactAppboy.logContentCardsDisplayed(cardId);
-      }
-    }).catch(function () {
-      console.log("Content Cards Promise Rejected");
-    });
+      })
+      .catch(function() {
+        console.log('Content Cards Promise Rejected');
+      });
   }
 }
 
@@ -615,41 +692,41 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#F5FCFF',
     paddingTop: 100,
-    paddingBottom: 100
+    paddingBottom: 100,
   },
   textInput: {
     height: 40,
     width: 150,
     borderColor: 'gray',
-    borderWidth: .5,
+    borderWidth: 0.5,
     paddingLeft: 5,
     marginLeft: 5,
-    fontSize: 14
+    fontSize: 14,
   },
   row: {
     flexDirection: 'row',
-    alignItems: 'center'
+    alignItems: 'center',
   },
   picker: {
-    width: 200
+    width: 200,
   },
   toastView: {
-    display: "flex",
+    display: 'flex',
     height: 80,
-    backgroundColor: "green",
-    position: "absolute",
+    backgroundColor: 'green',
+    position: 'absolute',
     left: 0,
     top: 0,
     right: 0,
-    alignItems: "center",
-    flexDirection: 'row'
+    alignItems: 'center',
+    flexDirection: 'row',
   },
   toastText: {
     marginLeft: 10,
     color: 'white',
     fontSize: 15,
-    fontWeight: 'bold'
-  }
+    fontWeight: 'bold',
+  },
 });
 
 export default AppboyProject;

--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -708,4 +708,9 @@ RCT_EXPORT_METHOD(requestPermission
   }
 }
 
+RCT_EXPORT_METHOD(registerDeviceForRemoteNotifications)
+{
+    [[UIApplication sharedApplication] registerForRemoteNotifications];
+}
+
 @end

--- a/index.d.ts
+++ b/index.d.ts
@@ -575,6 +575,25 @@ export function logInAppMessageButtonClicked(
   buttonId: number
 ): void;
 
+interface PermissionOptions {
+
+}
+
+export enum PermissionStatus {
+  NOT_DETERMINED = 0,
+  DENIED = -1,
+  AUTHORIZED = 1,
+  PROVISIONAL = 2
+}
+
+/**
+ * Request notification permission for ios, always returns true on android
+ * @param {PermissionOptions} permissionOptions
+ */
+export function requestPermission(
+  permissionOptions?: PermissionOptions,
+): Promise<PermissionStatus>;
+
 export class BrazeInAppMessage {
   constructor(_data: string)
   inAppMessageJsonString: string
@@ -592,7 +611,6 @@ export class BrazeInAppMessage {
   buttons: [BrazeButton]
   toString(): string;
 }
-
 export class BrazeButton {
   constructor(_data: string)
   text: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -594,6 +594,12 @@ export function requestPermission(
   permissionOptions?: PermissionOptions,
 ): Promise<PermissionStatus>;
 
+/**
+ * Register device for remote notifications, no-op on android
+ * @platform ios
+ */
+export function registerDeviceForRemoteNotifications(): void;
+
 export class BrazeInAppMessage {
   constructor(_data: string)
   inAppMessageJsonString: string

--- a/index.js
+++ b/index.js
@@ -707,9 +707,9 @@ var ReactAppboy = {
     return true
   },
   /**
- * Register device for remote notifications, no-op on android
- * @platform ios
- */
+   * Register device for remote notifications, no-op on android
+   * @platform ios
+   */
   registerDeviceForRemoteNotifications: function() {
     if(Platform.OS === 'ios') {
       return AppboyReactBridge.registerDeviceForRemoteNotifications()

--- a/index.js
+++ b/index.js
@@ -706,6 +706,15 @@ var ReactAppboy = {
     }
     return true
   },
+  /**
+ * Register device for remote notifications, no-op on android
+ * @platform ios
+ */
+  registerDeviceForRemoteNotifications: function() {
+    if(Platform.OS === 'ios') {
+      return AppboyReactBridge.registerDeviceForRemoteNotifications()
+    }
+  },
   // Events
   /**
    * Subscribes to the specific SDK event.

--- a/index.js
+++ b/index.js
@@ -694,7 +694,18 @@ var ReactAppboy = {
     const inAppMessageString = inAppMessage.toString();
     AppboyReactBridge.logInAppMessageButtonClicked(inAppMessageString, buttonId);
   },
-
+  /**
+   * Request notification permission for ios, always returns true on android
+   * @platform ios
+   * @param {*} permissionOptions 
+   * @returns 
+   */
+  requestPermission: function(permissionOptions) {
+    if(Platform.OS === 'ios') {
+      return AppboyReactBridge.requestPermission(permissionOptions)
+    }
+    return true
+  },
   // Events
   /**
    * Subscribes to the specific SDK event.


### PR DESCRIPTION
# **Problem**
Right now in the example app and according to documentation we need to request notification permission when a user opens the app. Sometimes, this behavior is not expected and decreases user experience. 

# **Solution**
Added `requestPermission()` and `registerDeviceForRemoteNotifications()` functions for iOS. 