### PR TITLE
fix: getInitialUrl() deadlock on iOS

### DIFF
--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -82,6 +82,8 @@ RCT_EXPORT_METHOD(setSDKFlavor) {
 RCT_EXPORT_METHOD(getInitialUrl:(RCTResponseSenderBlock)callback) {
   if ([AppboyReactUtils sharedInstance].initialUrlString != nil) {
     [self reportResultWithCallback:callback andError:nil andResult:[AppboyReactUtils sharedInstance].initialUrlString];
+  } else {
+    [self reportResultWithCallback:callback andError:nil andResult:nil];
   }
 }
 


### PR DESCRIPTION
`getInitialUrl()` will never resolve nor reject when it's null. This commit fixes the issue.