### PR TITLE
fix: use kotlinVersion for standard syntax

### DIFF
--- a/AppboyProject/android/build.gradle
+++ b/AppboyProject/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.0'
+    ext.kotlinVersion = '1.6.0'
 
     repositories {
         google()
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "com.google.gms:google-services:4.3.4"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ android {
 dependencies {
   api 'com.appboy:android-sdk-ui:23.0.1'
   api 'com.facebook.react:react-native:+'
-  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }


### PR DESCRIPTION
React Native has already a standardised way of setting the kotlin version so I think this library should use the same variable.

Example (look for `Need to use a custom Kotlin version?`: https://github.com/software-mansion/react-native-screens#android)