### PR TITLE
Use React-Core instead of React in podspec

### DIFF
--- a/react-native-appboy-sdk.podspec
+++ b/react-native-appboy-sdk.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'iOS/**/*.{h,m}'
 
   s.dependency 'Appboy-iOS-SDK', '~> 4.5.0'
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Fixes https://github.com/Appboy/appboy-react-sdk/issues/104

This PR replaces the podspec dependency "React" with "React-Core". This will also unblock migrating away from the legacy build system.