### PR TITLE
Fix dependency for build of RN 0.69+

### DIFF
--- a/react-native-appboy-sdk.podspec
+++ b/react-native-appboy-sdk.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'iOS/**/*.{h,m}'
 
   s.dependency 'Appboy-iOS-SDK', '~> 4.5.0'
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
iOS Build fails when the dependency is set to 'React'. We're using patch-package now to work around it.