### PR TITLE
[android] `getContentCards` promise safety

### DIFF
--- a/android/src/main/java/com/braze/reactbridge/BrazeReactBridgeImpl.kt
+++ b/android/src/main/java/com/braze/reactbridge/BrazeReactBridgeImpl.kt
@@ -373,10 +373,18 @@ class BrazeReactBridgeImpl(
     }
 
     fun getContentCards(promise: Promise) {
-        braze.subscribeToContentCardsUpdates(IEventSubscriber { message ->
-            promise.resolve(mapContentCards(message.allCards))
+        var subscriber = IEventSubscriber<ContentCardsUpdatedEvent>? = null
+        subscriber = IEventSubscriber { message ->
+            subscriber?.let {
+                braze.removeSingleSubscription(it, ContentCardsUpdatedEvent::class.java)
+            }
+            subscriber = null
             updateContentCardsIfNeeded(message)
-        })
+            if (reactApplicationContext.hasActiveReactInstance()) {
+                promise.resolve(mapContentCards(message.allCards))
+            }
+        }
+        braze.subscribeToContentCardsUpdates(subscriber!!)
         braze.requestContentCardsRefresh()
     }
 

--- a/android/src/main/java/com/braze/reactbridge/BrazeReactBridgeImpl.kt
+++ b/android/src/main/java/com/braze/reactbridge/BrazeReactBridgeImpl.kt
@@ -373,7 +373,7 @@ class BrazeReactBridgeImpl(
     }
 
     fun getContentCards(promise: Promise) {
-        var subscriber = IEventSubscriber<ContentCardsUpdatedEvent>? = null
+        var subscriber: IEventSubscriber<ContentCardsUpdatedEvent>? = null
         subscriber = IEventSubscriber { message ->
             subscriber?.let {
                 braze.removeSingleSubscription(it, ContentCardsUpdatedEvent::class.java)


### PR DESCRIPTION
I am seeing an app crash on Android in the Google play console, that I am not sure how to reproduce yet. Looking at the stack trace it seems that `getContentCards` is trying to return a promise that is either invalid or already used.


**Snippet:** 
```
com.facebook.react.bridge.CxxCallbackImpl.invoke+28
com.facebook.react.bridge.PromiseImpl.resolve+16
com.braze.reactbridge.BrazeReactBridgeImpl.getContentCards$lambda$34+26
com.braze.reactbridge.BrazeReactBridgeImpl.i
com.braze.reactbridge.f.trigger+12
com.braze.events.c.invokeSuspend+20
```

Given I am not sure how to reproduce it I tried to solve it in 3 ways:

1. **Removes the subscriber after it fires** -- The promise can only be used once, so `braze.removeSingleSubscription(it, ContentCardsUpdatedEvent::class.java)` prevents accumulation. Setting subscriber = null makes the removal idempotent if it fires more than once.

2. **Guards with hasActiveReactInstance()** -- matches the pattern already used by `subscribeToContentCardsUpdatedEvent`. If the React instance is torn down, `promise.resolve()` is skipped entirely, avoiding the CxxCallbackImpl crash.

3. **Calls updateContentCardsIfNeeded before the guard** -- the cache should still be updated regardless of whether the JS layer is alive.


I could totally be off base here and I am open to feedback, but I do think something is going on in the `getContentCards` causing the crash.



**Full stack trace:**
```
#00  pc 0x00000000000754ec  /apex/com.android.runtime/lib64/bionic/libc.so (abort+156)
#01  pc 0x0000000000555218  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/split_config.arm64_v8a.apk!libreactnative.so (google::logging_fail()+73990144) (BuildId: daceecb3f8ffe4c2)
#02  pc 0x0000000000554378  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/split_config.arm64_v8a.apk!libreactnative.so (google::LogMessage::SendToLog()+1792) (BuildId: daceecb3f8ffe4c2)
#03  pc 0x0000000000554a84  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/split_config.arm64_v8a.apk!libreactnative.so (google::LogMessage::Flush()+216) (BuildId: daceecb3f8ffe4c2)
#04  pc 0x0000000000558f28  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/split_config.arm64_v8a.apk!libreactnative.so (google::LogMessageFatal::~LogMessageFatal()+8) (BuildId: daceecb3f8ffe4c2)
#05  pc 0x00000000003a991c  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/split_config.arm64_v8a.apk!libreactnative.so (std::__ndk1::__function::__func<facebook::react::(anonymous namespace)::createJavaCallback(facebook::jsi::Runtime&, facebook::jsi::Function&&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>)::$_0, std::__ndk1::allocator<facebook::react::(anonymous namespace)::createJavaCallback(facebook::jsi::Runtime&, facebook::jsi::Function&&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>)::$_0>, void (folly::dynamic)>::operator()(folly::dynamic&&)+73990144) (BuildId: daceecb3f8ffe4c2)
#06  pc 0x000000000046fa14  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/split_config.arm64_v8a.apk!libreactnative.so (facebook::jni::detail::MethodWrapper<void (facebook::react::JCxxCallbackImpl::*)(facebook::react::NativeArray*), &facebook::react::JCxxCallbackImpl::invoke(facebook::react::NativeArray*), facebook::react::JCxxCallbackImpl, void, facebook::react::NativeArray*>::dispatch(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::JCxxCallbackImpl, facebook::react::JCallback>::JavaPart, facebook::react::JCallback, void>::_javaobject*>, facebook::react::NativeArray*&&)+120) (BuildId: daceecb3f8ffe4c2)
#07  pc 0x000000000046f924  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/split_config.arm64_v8a.apk!libreactnative.so (facebook::jni::detail::MethodWrapper<void (facebook::react::JCxxCallbackImpl::*)(facebook::react::NativeArray*), &facebook::react::JCxxCallbackImpl::invoke(facebook::react::NativeArray*), facebook::react::JCxxCallbackImpl, void, facebook::react::NativeArray*>::call(_JNIEnv*, _jobject*, facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::NativeArray, facebook::jni::detail::BaseHybridClass>::JavaPart, facebook::jni::JObject, void>::_javaobject*)+76) (BuildId: daceecb3f8ffe4c2)
#08  pc 0x0000000000d5234c  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+124)
#09  pc 0x0000000000669380  /apex/com.android.art/lib64/libart.so (nterp_helper+4016)
#10  pc 0x000000000031b19c  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (com.facebook.react.bridge.CxxCallbackImpl.invoke+28)
#11  pc 0x000000000066a144  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
#12  pc 0x0000000000321514  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (com.facebook.react.bridge.PromiseImpl.resolve+16)
#13  pc 0x000000000066a144  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
#14  pc 0x000000000053a74a  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (com.braze.reactbridge.BrazeReactBridgeImpl.getContentCards$lambda$34+26)
#15  pc 0x0000000000668404  /apex/com.android.art/lib64/libart.so (nterp_helper+52)
#16  pc 0x000000000053a13c  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (com.braze.reactbridge.BrazeReactBridgeImpl.i)
#17  pc 0x0000000000668404  /apex/com.android.art/lib64/libart.so (nterp_helper+52)
#18  pc 0x0000000000537594  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (com.braze.reactbridge.f.trigger+12)
#19  pc 0x000000000066a144  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
#20  pc 0x00000000004ffaf4  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (com.braze.events.c.invokeSuspend+20)
#21  pc 0x0000000000669324  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
#22  pc 0x000000000049d66e  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (kotlin.coroutines.jvm.internal.a.resumeWith+22)
#23  pc 0x00000000001d9150  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/oat/arm64/base.odex (kotlinx.coroutines.c0.run+2288)
#24  pc 0x000000000066a1a4  /apex/com.android.art/lib64/libart.so (nterp_helper+7636)
#25  pc 0x000000000027fb42  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (kotlinx.coroutines.internal.l$a.run+6)
#26  pc 0x000000000066a144  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
#27  pc 0x0000000000284248  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (kotlinx.coroutines.scheduling.i.run+4)
#28  pc 0x000000000066a144  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
#29  pc 0x0000000000283c28  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (kotlinx.coroutines.scheduling.a.d0)
#30  pc 0x0000000000669324  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
#31  pc 0x0000000000282d76  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (kotlinx.coroutines.scheduling.a$c.b+66)
#32  pc 0x0000000000669324  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
#33  pc 0x0000000000282e80  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (kotlinx.coroutines.scheduling.a$c.n+56)
#34  pc 0x0000000000669324  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
#35  pc 0x0000000000282e30  /data/app/~~F5-1LbH2Xzy41GH3TjZw0Q==/com.some.bundle-E4gV3q1A2-Nd1B61Z14I1g==/base.apk (kotlinx.coroutines.scheduling.a$c.run)
#36  pc 0x00000000002aad94  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+612)
#37  pc 0x00000000002707ac  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+220)
#38  pc 0x00000000004bdc28  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallback(void*)+1184)
#39  pc 0x00000000004bd778  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallbackWithUffdGc(void*)+8)
#40  pc 0x0000000000087d9c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*) (.__uniq.6734704868364011036884358442506)+236)
#41  pc 0x0000000000078950  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64)
```