### PR TITLE
Declare `static_framework` in the iOS podspec to support `use_frameworks! :linkage => :dynamic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+##### Fixed
+- Declares `static_framework = true` in the iOS podspec, allowing installation in apps using `use_frameworks! :linkage => :dynamic`.
+  - Previously, CocoaPods rejected the install because the pod would build as a dynamic framework while linking the static Braze Swift SDK binaries. The pod now always builds as a static framework when `use_frameworks!` is enabled, matching the approach used by Firebase and GoogleMaps.
+  - This has no effect on projects that don't use `use_frameworks!` or that use `use_frameworks! :linkage => :static`.
+
 ## 22.0.0
 
 ##### Breaking

--- a/braze-react-native-sdk.podspec
+++ b/braze-react-native-sdk.podspec
@@ -16,6 +16,11 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
   s.platform       = :ios, '12.0'
 
+  # The Braze Swift SDK binaries (BrazeKit, BrazeLocation, BrazeUI) are statically linked.
+  # Always build this pod as a static framework so that dynamic `use_frameworks!` setups
+  # do not embed duplicate copies of the Braze SDK.
+  s.static_framework = true
+
   s.preserve_paths = 'LICENSE.md', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'iOS/**/*.{h,m,mm,swift}'
 


### PR DESCRIPTION
## Summary

Adds `s.static_framework = true` to `braze-react-native-sdk.podspec`.

The Braze Swift SDK ships as static-only binary xcframeworks (BrazeKit, BrazeLocation, BrazeUI). `braze-react-native-sdk` is a source pod linking those binaries, so in apps using `use_frameworks! :linkage => :dynamic`, CocoaPods' target validator rejects the install:

```
[!] The 'Pods-BrazeProject' target has transitive dependencies that include statically linked binaries: (BrazeKit.xcframework and BrazeLocation.xcframework)
```

The validator enforces that a pod built as a dynamic framework may not link vendored static binaries: each dynamic consumer would embed its own copy of the Braze SDK, producing duplicate classes and split singleton state at runtime.

Declaring `s.static_framework = true` makes the pod always build as a static framework whenever `use_frameworks!` is enabled, regardless of the requested linkage, so Braze code is resolved once at the app's final link. This is the same mechanism Firebase's CocoaPods and GoogleMaps have used for years.

Motivation: firebase-ios-sdk's SPM distribution requires dynamic linkage, so React Native apps are increasingly migrating to `use_frameworks! :linkage => :dynamic` — and currently can't install Braze without a `pre_install` hook in their Podfile that forcibly overrides the pod's build type.

## Impact matrix

| Podfile configuration | Before | After |
|---|---|---|
| No `use_frameworks!` (React Native default) | Static library | **No change.** `static_framework` only takes effect when `use_frameworks!` is active; the pod target's product type remains `com.apple.product-type.library.static` (verified on a clean install). |
| `use_frameworks! :linkage => :static` | Static framework | **No-op** — already built as a static framework. |
| `use_frameworks! :linkage => :dynamic` | ❌ `pod install` rejected with the validator error above | ✅ Installs. The pod builds as a static framework and links once into the app binary. |

## Verification

Ran against the repo's example app (`BrazeProject`, CocoaPods 1.14.3 via bundler):

- **Dynamic**: `USE_FRAMEWORKS=dynamic bundle exec pod install` fails on `master` with the validator error quoted above; passes with this change.
- **Default (no `use_frameworks!`)**: clean `pod install` passes and the `braze-react-native-sdk` pod target still builds as a static library (product type unchanged — strict no-op), and the example app builds successfully with `xcodebuild`.
- **Static**: `USE_FRAMEWORKS=static` remains a no-op.

## Expo compatibility

No change is needed on the Expo side: `ExpoAdapterBraze.podspec` in braze-inc/braze-expo-plugin has declared `s.static_framework = true` since v0.1.0 (initial commit). With this PR, the whole chain is static — ExpoAdapterBraze → braze-react-native-sdk → Braze Swift SDK xcframeworks — so Expo apps using expo-build-properties `useFrameworks: "dynamic"` are covered by this PR alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
